### PR TITLE
add `Remotes` to `DESCRIPTION` file so `pak::local_install_deps()` works

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,9 @@ Imports:
     rlang,
     tidyr,
     vroom
+Remotes:
+    rmi-pacta/pacta.multi.loanbook.analysis,
+    rmi-pacta/pacta.multi.loanbook.plot
 Depends:
     R (>= 4.1.0)
 License: MIT + file LICENSE


### PR DESCRIPTION
add `Remotes` to `DESCRIPTION` file so `pak::local_install_deps()` works, otherwise `pak` won't no where to find the rmi-pacta pkgs because they're not released on CRAN (adding the remotes specification allows `pak` to automatically infer they're available from GitHub)