### PR TITLE
simplify matching of only files with a ".csv" extension

### DIFF
--- a/run_matching.R
+++ b/run_matching.R
@@ -153,7 +153,7 @@ if (matching_use_own_sector_classification) {
 }
 
 ## load raw loan books----
-list_raw <- list.files(dir_raw)[grepl(".csv", list.files(dir_raw))]
+list_raw <- list.files(path = dir_raw, pattern = "[.]csv$")
 
 if (length(list_raw) == 0) {
   stop(glue::glue("No raw loan book csvs found in {dir_raw}. Please check your project setup!"))


### PR DESCRIPTION
note: `[.]` is a "character class" in which the period is interpreted literally rather than as a meta-character. Some would argue it's more "proper" to use `\\.` which escapes the meta-character so that it's interpreted literally, but I find having to escape the escape, i.e. `\\`, so R's string interpreter doesn't muck up the regex tedious and somewhat confusing.