### PR TITLE
simplify extraction of filename from filepath

### DIFF
--- a/run_matching.R
+++ b/run_matching.R
@@ -164,10 +164,7 @@ raw_lbk <- vroom::vroom(
   col_types = col_types_raw,
   id = "group_id"
 ) %>%
-  dplyr::mutate(
-    group_id = gsub(glue::glue("{dir_raw}/"), "", .data$group_id),
-    group_id = gsub(".csv", "", .data$group_id)
-  ) %>%
+  dplyr::mutate(group_id = tools::file_path_sans_ext(basename(.data$group_id))) %>%
   dplyr::group_split(.data$group_id)
 
 # match and save loan books----


### PR DESCRIPTION
note: `tools` and therefore `tools::file_path_sans_ext()` are part of base R (for a proper R package, one would probably have to list `tools` in the `Imports` in the DESCRIPTION file