### PR TITLE
replace explicit usage of `rlang` with modern `dplyr` guidance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
     r2dii.plot,
     readr,
     readxl,
-    rlang,
     tidyr,
     vroom,
     withr

--- a/prepare_abcd.R
+++ b/prepare_abcd.R
@@ -110,8 +110,8 @@ rm_inactive_companies <- function(data,
       values_from = "sum_production"
     ) %>%
     dplyr::filter(
-      !!rlang::sym(paste0("prod_", start_year)) > 0,
-      !!rlang::sym(paste0("prod_", start_year + time_frame)) == 0
+      .data[[paste0("prod_", start_year)]] > 0,
+      .data[[paste0("prod_", start_year + time_frame)]] == 0
     ) %>%
     dplyr::distinct(
       .data$name_company,


### PR DESCRIPTION
The [modern recommendation for doing indirection](https://dplyr.tidyverse.org/articles/programming.html#indirection) with an environment variable is to use the `.data` pronoun with `[[`, and this reduces complexity a bit by not needing to use `rlang` directly.