### PR TITLE
use `readr` instead of `vroom` for importing CSVs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,11 +24,10 @@ Imports:
     r2dii.data,
     r2dii.match,
     r2dii.plot,
-    readr,
+    readr (>= 2.0.0),
     readxl,
     rlang,
     tidyr,
-    vroom,
     withr
 Remotes:
     rmi-pacta/pacta.multi.loanbook.analysis,

--- a/run_calculate_match_success_rate.R
+++ b/run_calculate_match_success_rate.R
@@ -4,6 +4,7 @@ library(ggplot2)
 library(r2dii.data)
 library(r2dii.match)
 library(r2dii.plot)
+library(readr)
 library(tidyr)
 library(withr)
 
@@ -95,7 +96,7 @@ if (length(list_raw) == 0) {
   stop(glue::glue("No raw loan book csvs found in {dir_raw}. Please check your project setup!"))
 }
 
-raw_lbk <- vroom::vroom(
+raw_lbk <- readr::read_csv(
   file = file.path(dir_raw, list_raw),
   col_types = col_types_raw,
   id = "group_id"
@@ -112,7 +113,7 @@ if (length(list_matched_prioritized) == 0) {
   stop(glue::glue("No matched prioritized loan book csvs found in {dir_matched}. Please check your project setup!"))
 }
 
-matched_prioritized <- vroom::vroom(
+matched_prioritized <- readr::read_csv(
   file = file.path(dir_matched, list_matched_prioritized),
   col_types = col_types_matched_prioritized,
   col_select = dplyr::all_of(col_select_matched_prioritized)

--- a/run_match_prioritize.R
+++ b/run_match_prioritize.R
@@ -2,7 +2,6 @@
 library(dplyr, warn.conflicts = FALSE)
 library(r2dii.match)
 library(readr)
-library(vroom)
 
 # source helpers----
 source("expected_columns.R")
@@ -44,7 +43,7 @@ if (length(list_matched_manual) == 0) {
   stop(glue::glue("No manually matched loan book csvs found in {dir_matched}. Please check your project setup!"))
 }
 
-matched_lbk_manual <- vroom::vroom(
+matched_lbk_manual <- readr::read_csv(
   file = file.path(dir_matched, list_matched_manual),
   col_types = col_types_matched_manual#,
   # col_select = dplyr::all_of(col_select_matched_manual)

--- a/run_matching.R
+++ b/run_matching.R
@@ -159,7 +159,7 @@ if (length(list_raw) == 0) {
   stop(glue::glue("No raw loan book csvs found in {dir_raw}. Please check your project setup!"))
 }
 
-raw_lbk <- vroom::vroom(
+raw_lbk <- readr::read_csv(
   file = file.path(dir_raw, list_raw),
   col_types = col_types_raw,
   id = "group_id"


### PR DESCRIPTION
Since [readr v2.0.0 (2021-07-20)](https://readr.tidyverse.org/news/index.html#readr-200) / "second edition", readr uses vroom under the hood and has the same functionality of reading multiple CSVs at the same time. Ultimately, vroom is still an indirect dependency, but I think using `readr::read_csv()` is the currently recommended approach versus `vroom::vroom()`, plus it reduces complexity a bit.