### PR TITLE
unify parameters specifying ABCD data

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -28,8 +28,6 @@ default:
     # sector_split_type: "worst_case"
     dir_split_company_id: "path/to/split_folder"
     filename_split_company_id: "split_company_ids.csv"
-    dir_advanced_company_indicators: "path/to/advanced_company_indicators_folder"
-    filename_advanced_company_indicators: "advanced_company_indicators.xlsx"
   matching:
     prep_input_level: "direct_loantaker"
     params_match_name:

--- a/prepare_sector_split.R
+++ b/prepare_sector_split.R
@@ -53,11 +53,11 @@ path_sector_split <- file.path(
 )
 
 path_advanced_company_indicators <- file.path(
-  config_prepare_sector_split$dir_advanced_company_indicators,
-  config_prepare_sector_split$filename_advanced_company_indicators
+  config_dir$dir_abcd,
+  config_files$filename_abcd
 )
 
-sheet_advanced_company_indicators <- config_prepare_sector_split$sheet_advanced_company_indicators
+sheet_advanced_company_indicators <- config_files$sheet_abcd
 
 start_year <- config_project_parameters$start_year
 time_frame <- config_project_parameters$time_frame


### PR DESCRIPTION
- closes #36
- closes #37

⚠️ I see now that (maybe) the sector split requires the (not P4B) Advanced Company Indicators while the other scripts require the P4B data format, so these parameters likely cannot be unified?