### PR TITLE
Progress bar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Description: This repo allows running PACTA analyses on multiple loan books in a
     exported to specified project paths.
 Encoding: UTF-8
 Imports:
+    cli (>= 3.2.0),
     config,
     dplyr,
     ggplot2,

--- a/run_matching.R
+++ b/run_matching.R
@@ -168,7 +168,7 @@ raw_lbk <- readr::read_csv(
   dplyr::group_split(.data$group_id)
 
 # match and save loan books----
-for (i in 1:length(raw_lbk)) {
+for (i in cli::cli_progress_along(raw_lbk, "Matching loanbooks")) {
   group_name <- unique(raw_lbk[[i]]$group_id)
 
   ## match data----


### PR DESCRIPTION
add a progress bar for when matching loanbooks takes a bit of time

adds dependency on {cli}, but I was already planning to suggest it to make [better error and warning messages](https://github.com/RMI-PACTA/workflow.multi.loanbook/compare/main...cli-conditions)