### PR TITLE
remove `filename_raw` from example config

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -6,7 +6,6 @@ default:
     dir_matched: "path/to/matched_folder"
     dir_output: "path/to/output_folder"
   file_names:
-    filename_raw: "raw_loanbook_123.csv"
     filename_scenario_tms: "scenarios_2022_tms.csv"
     filename_scenario_sda: "scenarios_2022_sda.csv"
     filename_abcd: "abcd.xlsx"


### PR DESCRIPTION
I think `filename_raw` is no longer in use since the scripts automatically take every CSV they find in the `raw` directory?

```yml
    filename_raw: "raw_loanbook_123.csv"
```