### PR TITLE
various clean up fixes in prep for making it a package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,13 +20,16 @@ Imports:
     dplyr,
     ggplot2,
     glue,
+    janitor,
     pacta.multi.loanbook.analysis,
     pacta.multi.loanbook.plot,
+    r2dii.analysis,
     r2dii.data,
     r2dii.match,
     r2dii.plot,
     readr (>= 2.0.0),
     readxl,
+    rlang,
     tidyr,
     withr
 Remotes:

--- a/helper_functions.R
+++ b/helper_functions.R
@@ -1,58 +1,66 @@
-lost_companies_sector_split <- function(abcd,
-                                        companies_sector_split) {
-  abcd_id <- abcd %>%
-    dplyr::distinct(.data$company_id, .data$name_company)
-
-  # identify lost_companies_sector_split and write to csv for inspection
-  lost_companies_sector_split <- companies_sector_split %>%
-    dplyr::anti_join(
-      abcd_id,
-      by = c("company_id")
+lost_companies_sector_split <- function(abcd, companies_sector_split) {
+  abcd_id <-
+    dplyr::distinct(
+      .data = abcd,
+      .data[["company_id"]],
+      .data[["name_company"]]
     )
 
-  return(lost_companies_sector_split)
+  dplyr::anti_join(
+    x = companies_sector_split,
+    y = abcd_id,
+    by = c("company_id")
+  )
 }
 
 apply_sector_split_to_loans <- function(data,
                                         abcd,
                                         companies_sector_split) {
-  unique_companies_pre_split <- data %>%
-    distinct(name_abcd)
+  unique_companies_pre_split <- dplyr::distinct(.data = data, "name_abcd")
 
-  abcd_id <- abcd %>%
-    dplyr::distinct(.data$company_id, .data$name_company)
+  abcd_id <-
+    dplyr::distinct(
+      .data = abcd,
+      .data[["company_id"]],
+      .data[["name_company"]]
+    )
 
-  companies_sector_split <- companies_sector_split %>%
+  companies_sector_split <-
     dplyr::left_join(
-      abcd_id,
+      x = companies_sector_split,
+      y = abcd_id,
       by = c("company_id")
     ) %>%
     dplyr::select(-"company_id")
 
-  data <- data %>%
+  data <-
     dplyr::inner_join(
-      companies_sector_split,
+      x = data,
+      y = companies_sector_split,
       by = c("name_abcd" = "name_company", "sector_abcd" = "sector")
     ) %>%
     dplyr::mutate(
       # renaming the loan_id is not conditional to avoid any chance of accidentally
       # renaming a split loan to a loan_id that already exists elsewhere
-      id_loan = paste(.data$id_loan, .data$sector_abcd, sep = "_"),
+      id_loan = paste(.data[["id_loan"]], .data[["sector_abcd"]], sep = "_"),
       loan_size_outstanding = dplyr::if_else(
-        is.na(.data$sector_split),
-        .data$loan_size_outstanding,
-        .data$loan_size_outstanding * .data$sector_split
+        is.na(.data[["sector_split"]]),
+        .data[["loan_size_outstanding"]],
+        .data[["loan_size_outstanding"]] * .data[["sector_split"]]
       ),
       loan_size_credit_limit = dplyr::if_else(
-        is.na(.data$sector_split),
-        .data$loan_size_credit_limit,
-        .data$loan_size_credit_limit * .data$sector_split
+        is.na(.data[["sector_split"]]),
+        .data[["loan_size_credit_limit"]],
+        .data[["loan_size_credit_limit"]] * .data[["sector_split"]]
       )
     ) %>%
     dplyr::select(-"sector_split")
 
-  unique_companies_post_split <- data %>%
-    distinct(name_abcd)
+  unique_companies_post_split <-
+    dplyr::distinct(
+      .data = data,
+      .data[["name_abcd"]]
+    )
 
   if (nrow(unique_companies_pre_split) != nrow(unique_companies_post_split)) {
     warning(
@@ -65,5 +73,5 @@ apply_sector_split_to_loans <- function(data,
     )
   }
 
-  return(data)
+  data
 }

--- a/plots.R
+++ b/plots.R
@@ -53,8 +53,8 @@ plot_match_success_rate <- function(data,
 
   theme_match_success <- ggplot2::theme(
     legend.position = "top",
-    legend.title = element_blank(),
-    axis.text.x = element_text(angle = 90, vjust = 0.5, hjust=1)
+    legend.title = ggplot2::element_blank(),
+    axis.text.x = ggplot2::element_text(angle = 90, vjust = 0.5, hjust=1)
   )
 
   # plot description
@@ -93,9 +93,9 @@ plot_match_success_rate <- function(data,
   plot <- data %>%
     ggplot2::ggplot(
       ggplot2::aes(
-        x = r2dii.plot::to_title(sector),
-        y = match_success_rate,
-        fill = matched
+        x = r2dii.plot::to_title(.data[["sector"]]),
+        y = .data[["match_success_rate"]],
+        fill = .data[["matched"]]
       )
     ) +
     ggplot2::geom_col(
@@ -182,7 +182,7 @@ generate_individual_outputs <- function(data,
         dplyr::between(.data$year, .env$start_year, .env$start_year + .env$time_horizon)
       ) %>%
       dplyr::mutate(
-        label = case_when(
+        label = dplyr::case_when(
           .data$metric == "projected" ~ "Portfolio",
           .data$metric == "corporate_economy" ~ "Corporate Economy",
           .data$metric == .env$target_scenario ~ glue::glue("{r2dii.plot::to_title(toupper(.env$scenario))} Scenario")
@@ -451,7 +451,7 @@ validate_input_data_generate_individual_outputs <- function(data,
                                                             matched_prioritized,
                                                             target_type) {
   if (target_type == "sda") {
-    validate_data_has_expected_cols(
+    pacta.multi.loanbook.analysis::validate_data_has_expected_cols(
       data = data,
       expected_columns = c(
         "sector", "year", "region", "scenario_source", "emission_factor_metric",
@@ -459,7 +459,7 @@ validate_input_data_generate_individual_outputs <- function(data,
       )
     )
   } else if (target_type == "tms") {
-    validate_data_has_expected_cols(
+    pacta.multi.loanbook.analysis::validate_data_has_expected_cols(
       data = data,
       expected_columns = c(
         "sector", "technology", "year", "region", "scenario_source", "metric",
@@ -469,7 +469,7 @@ validate_input_data_generate_individual_outputs <- function(data,
     )
   }
 
-  validate_data_has_expected_cols(
+  pacta.multi.loanbook.analysis::validate_data_has_expected_cols(
     data = matched_prioritized,
     expected_columns = c(
       "group_id", "name_abcd", "sector", "sector_abcd", "loan_size_outstanding",

--- a/prepare_abcd.R
+++ b/prepare_abcd.R
@@ -98,7 +98,7 @@ rm_inactive_companies <- function(data,
                                   time_frame) {
   comp_sec_no_prod_t5 <- data %>%
     dplyr::filter(
-      year %in% c(.env$start_year, .env$start_year + .env$time_frame)
+      .data[["year"]] %in% c(.env$start_year, .env$start_year + .env$time_frame)
     ) %>%
     dplyr::summarise(
       sum_production = sum(.data$production, na.rm = TRUE),
@@ -120,7 +120,7 @@ rm_inactive_companies <- function(data,
 
   comp_sec_no_prod_t0_to_t5 <- data %>%
     dplyr::filter(
-      year %in% c(.env$start_year, .env$start_year + .env$time_frame)
+      .data[["year"]] %in% c(.env$start_year, .env$start_year + .env$time_frame)
     ) %>%
     dplyr::summarise(
       sum_production = sum(.data$production, na.rm = TRUE),

--- a/prepare_sector_split.R
+++ b/prepare_sector_split.R
@@ -129,8 +129,8 @@ advanced_company_indicators <- advanced_company_indicators_raw %>%
   dplyr::select(
     -dplyr::all_of(
       c(
-        starts_with("direct_ownership_"),
-        starts_with("financial_control_")
+        dplyr::starts_with("direct_ownership_"),
+        dplyr::starts_with("financial_control_")
       )
     )
   ) %>%
@@ -238,7 +238,7 @@ sector_split_all_companies <- advanced_company_indicators %>%
 ### check that the sum of the sector split of each company is 1----
 check_sector_split_all_companies <- sector_split_all_companies %>%
   dplyr::summarise(
-    sum_share = sum(sector_split, na.rm = TRUE),
+    sum_share = sum(.data[["sector_split"]], na.rm = TRUE),
     .by = "company_id"
   )
 
@@ -319,7 +319,7 @@ sector_split_multi_energy_companies <- sector_split_multi_energy_companies %>%
 ### check that the sum of the primary energy based sector split of each company is 1----
 check_sector_split_multi_energy_companies <- sector_split_multi_energy_companies %>%
   dplyr::summarise(
-    sum_share = sum(sector_split, na.rm = TRUE),
+    sum_share = sum(.data[["sector_split"]], na.rm = TRUE),
     .by = "company_id"
   )
 
@@ -366,7 +366,7 @@ if (any(round(check_sector_split_all_companies_final$sum_share, 3) != 1)) {
 ## write output----
 sector_split_multi_energy_companies %>%
   dplyr::select(
-    all_of(
+    dplyr::all_of(
       c(
         "company_id",
         "name_company",
@@ -382,7 +382,7 @@ sector_split_multi_energy_companies %>%
 
 sector_split_all_companies %>%
   dplyr::select(
-    all_of(
+    dplyr::all_of(
       c(
         "company_id",
         "name_company",
@@ -398,7 +398,7 @@ sector_split_all_companies %>%
 
 sector_split_all_companies_final %>%
   dplyr::select(
-    all_of(
+    dplyr::all_of(
       c(
         "company_id",
         "name_company",

--- a/run_calculate_match_success_rate.R
+++ b/run_calculate_match_success_rate.R
@@ -248,14 +248,14 @@ lbk_match_success <- lbk_match_success %>%
 lbk_match_success_rate <- lbk_match_success %>%
   dplyr::mutate(
     total_n = dplyr::n(),
-    total_outstanding = sum(loan_size_outstanding, na.rm = TRUE),
-    total_credit_limit = sum(loan_size_credit_limit, na.rm = TRUE),
+    total_outstanding = sum(.data[["loan_size_outstanding"]], na.rm = TRUE),
+    total_credit_limit = sum(.data[["loan_size_credit_limit"]], na.rm = TRUE),
     .by = c("group_id", "sector")
   ) %>%
   dplyr::summarise(
     match_n = dplyr::n(),
-    match_outstanding = sum(loan_size_outstanding, na.rm = TRUE),
-    match_credit_limit = sum(loan_size_credit_limit, na.rm = TRUE),
+    match_outstanding = sum(.data[["loan_size_outstanding"]], na.rm = TRUE),
+    match_credit_limit = sum(.data[["loan_size_credit_limit"]], na.rm = TRUE),
     .by = c("group_id", "sector", "matched", "total_n", "total_outstanding", "total_credit_limit")
   ) %>%
   dplyr::mutate(

--- a/run_pacta.R
+++ b/run_pacta.R
@@ -173,11 +173,11 @@ sector_select <- "automotive"
 for (tms_i in unique_groups_tms) {
   available_rows <- results_tms_total %>%
     dplyr::filter(
-      group_id == tms_i,
-      scenario_source == scenario_source_input,
-      grepl(scenario_select, .data$metric),
-      region == region_select,
-      sector == sector_select
+      .data[["group_id"]] == .env[["tms_i"]],
+      .data[["scenario_source"]] == .env[["scenario_source_input"]],
+      grepl(.env[["scenario_select"]], .data$metric),
+      .data[["region"]] == .env[["region_select"]],
+      .data[["sector"]] == .env[["sector_select"]]
     ) %>%
     nrow()
   if (available_rows > 0) {
@@ -203,11 +203,11 @@ sector_select <- "coal"
 for (tms_i in unique_groups_tms) {
   available_rows <- results_tms_total %>%
     dplyr::filter(
-      group_id == tms_i,
-      scenario_source == scenario_source_input,
-      grepl(scenario_select, .data$metric),
-      region == region_select,
-      sector == sector_select
+      .data[["group_id"]] == .env[["tms_i"]],
+      .data[["scenario_source"]] == .env[["scenario_source_input"]],
+      grepl(.env[["scenario_select"]], .data$metric),
+      .data[["region"]] == .env[["region_select"]],
+      .data[["sector"]] == .env[["sector_select"]]
     ) %>%
     nrow()
   if (available_rows > 0) {
@@ -233,11 +233,11 @@ sector_select <- "oil and gas"
 for (tms_i in unique_groups_tms) {
   available_rows <- results_tms_total %>%
     dplyr::filter(
-      group_id == tms_i,
-      scenario_source == scenario_source_input,
-      grepl(scenario_select, .data$metric),
-      region == region_select,
-      sector == sector_select
+      .data[["group_id"]] == .env[["tms_i"]],
+      .data[["scenario_source"]] == .env[["scenario_source_input"]],
+      grepl(.env[["scenario_select"]], .data$metric),
+      .data[["region"]] == .env[["region_select"]],
+      .data[["sector"]] == .env[["sector_select"]]
     ) %>%
     nrow()
   if (available_rows > 0) {
@@ -263,11 +263,11 @@ sector_select <- "power"
 for (tms_i in unique_groups_tms) {
   available_rows <- results_tms_total %>%
     dplyr::filter(
-      group_id == tms_i,
-      scenario_source == scenario_source_input,
-      grepl(scenario_select, .data$metric),
-      region == region_select,
-      sector == sector_select
+      .data[["group_id"]] == .env[["tms_i"]],
+      .data[["scenario_source"]] == .env[["scenario_source_input"]],
+      grepl(.env[["scenario_select"]], .data$metric),
+      .data[["region"]] == .env[["region_select"]],
+      .data[["sector"]] == .env[["sector_select"]]
     ) %>%
     nrow()
   if (available_rows > 0) {
@@ -294,11 +294,11 @@ sector_select <- "aviation"
 for (sda_i in unique_groups_sda) {
   available_rows <- results_sda_total %>%
     dplyr::filter(
-      group_id == sda_i,
-      scenario_source == scenario_source_input,
-      grepl(scenario_select, .data$emission_factor_metric),
-      region == region_select,
-      sector == sector_select
+      .data[["group_id"]] == .env[["tms_i"]],
+      .data[["scenario_source"]] == .env[["scenario_source_input"]],
+      grepl(.env[["scenario_select"]], .data$emission_factor_metric),
+      .data[["region"]] == .env[["region_select"]],
+      .data[["sector"]] == .env[["sector_select"]]
     ) %>%
     nrow()
   if (available_rows > 0) {
@@ -324,11 +324,11 @@ sector_select <- "cement"
 for (sda_i in unique_groups_sda) {
   available_rows <- results_sda_total %>%
     dplyr::filter(
-      group_id == sda_i,
-      scenario_source == scenario_source_input,
-      grepl(scenario_select, .data$emission_factor_metric),
-      region == region_select,
-      sector == sector_select
+      .data[["group_id"]] == .env[["tms_i"]],
+      .data[["scenario_source"]] == .env[["scenario_source_input"]],
+      grepl(.env[["scenario_select"]], .data$emission_factor_metric),
+      .data[["region"]] == .env[["region_select"]],
+      .data[["sector"]] == .env[["sector_select"]]
     ) %>%
     nrow()
   if (available_rows > 0) {
@@ -354,11 +354,11 @@ sector_select <- "steel"
 for (sda_i in unique_groups_sda) {
   available_rows <- results_sda_total %>%
     dplyr::filter(
-      group_id == sda_i,
-      scenario_source == scenario_source_input,
-      grepl(scenario_select, .data$emission_factor_metric),
-      region == region_select,
-      sector == sector_select
+      .data[["group_id"]] == .env[["tms_i"]],
+      .data[["scenario_source"]] == .env[["scenario_source_input"]],
+      grepl(.env[["scenario_select"]], .data$emission_factor_metric),
+      .data[["region"]] == .env[["region_select"]],
+      .data[["sector"]] == .env[["sector_select"]]
     ) %>%
     nrow()
   if (available_rows > 0) {


### PR DESCRIPTION
A bunch of minor fixes to clean things up before transforming this repo to a R package.
- namespace all non-base R function calls
- reduce use of `%>%` where feasible
- use `.data` and `.env` pronouns in all "data-masking" functions
- use `.data[["col_name"]]` instead of `.data$col_name` pattern which is a tiny bit safer, e.g.
    ``` r
    mtcars$mp
    #>  [1] 21.0 21.0 22.8 21.4 18.7 18.1 14.3 24.4 22.8 19.2 17.8 16.4 17.3 15.2 10.4
    #> [16] 10.4 14.7 32.4 30.4 33.9 21.5 15.5 15.2 13.3 19.2 27.3 26.0 30.4 15.8 19.7
    #> [31] 15.0 21.4
    mtcars[["mp"]]
    #> NULL
    ```

@jacobvjk I'm hoping this is easier to follow if I make all these minor changes at once in a separate PR, rather than interspersing all these changes with the much more dramatic changes coming with making this a package (if I don't do this before or at the same time as making it a package, R CMD build results will be total chaos).