### PR TITLE
expand paths for safety since

### DIFF
--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -118,7 +118,7 @@ plot_aggregate_loanbooks <- function() {
       pacta.multi.loanbook.plot::plot_sankey(
         data_sankey_sector,
         group_var = by_group,
-        save_png_to = output_path_aggregated,
+        save_png_to = path.expand(output_path_aggregated),
         png_name = glue::glue("plot_{output_file_sankey_sector}.png"),
         nodes_order_from_data = TRUE
       )
@@ -159,7 +159,7 @@ plot_aggregate_loanbooks <- function() {
       pacta.multi.loanbook.plot::plot_sankey(
         data_sankey_company_sector,
         group_var = by_group,
-        save_png_to = output_path_aggregated,
+        save_png_to = path.expand(output_path_aggregated),
         png_name = glue::glue("plot_{output_file_sankey_company_sector}.png")
       )
     }


### PR DESCRIPTION
phantomjs does not properly expand `~/` to the user's home directory, and webshot and pacta.multi.loanbook.plot don't protect against that either, so we can do it here to be safe