### PR TITLE
unify the 2 `remove_inactive_companies` options; keep the one in the `prepare_abcd` section

### DIFF
--- a/R/load_config.R
+++ b/R/load_config.R
@@ -48,7 +48,7 @@ get_time_frame <- function(params) {
 }
 
 get_remove_inactive_companies <- function(params) {
-  params[["project_parameters"]][["remove_inactive_companies"]]
+  params[["prepare_abcd"]][["remove_inactive_companies"]]
 }
 
 get_scenario_source <- function(params) {

--- a/example.config.yml
+++ b/example.config.yml
@@ -20,7 +20,6 @@ default:
     time_frame: 5
     # regions must be available for the selected scenario
     benchmark_regions_select: "global,european union"
-    remove_inactive_companies: TRUE
   sector_split:
     apply_sector_split: TRUE
     sector_split_type: "equal_weights"


### PR DESCRIPTION
- closes #84 

(config loading utils already paying off 😉)