### PR TITLE
allow flexible `by_group` when reading `matched_prioritized`

### DIFF
--- a/R/expected_columns.R
+++ b/R/expected_columns.R
@@ -64,7 +64,7 @@ col_types_abcd_final <- c(
 )
 
 # expected columns matched_prioritized_all_groups file
-col_types_matched_prioritized <- readr::cols_only(
+col_types_matched_prioritized <- readr::cols(
   group_id = "c",
   id_loan = "c",
   id_direct_loantaker = "c",
@@ -87,7 +87,8 @@ col_types_matched_prioritized <- readr::cols_only(
   name_abcd = "c",
   score = "n",
   source = "c",
-  borderline = "l"
+  borderline = "l",
+  .default = "c"
 )
 col_select_matched_prioritized <- names(col_types_matched_prioritized[["cols"]])
 col_standard_matched_prioritized <- c(col_select_matched_prioritized[!col_select_matched_prioritized == "group_id"])

--- a/R/run_aggregate_alignment_metric.R
+++ b/R/run_aggregate_alignment_metric.R
@@ -63,7 +63,7 @@ run_aggregate_alignment_metric <- function(config) {
   matched_prioritized <- readr::read_csv(
     file = file.path(dir_matched, list_matched_prioritized),
     col_types = col_types_matched_prioritized,
-    col_select = dplyr::all_of(col_select_matched_prioritized)
+    col_select = dplyr::all_of(c(by_group, col_select_matched_prioritized))
   )
 
   # aggregate P4B alignment----


### PR DESCRIPTION
closes #87 

gains flexibility in running calculations by a grouping variable provided via the `by_group` parameter in the `config.yml` file.

E.g. allows producing an split of the underlying loan books by the variable `"foo"`, if this variable is provided in the loan books

![plot_sankey_sector_foo](https://github.com/user-attachments/assets/4140ea94-a7a2-4c1c-8733-87537bd40f48)
