### PR TITLE
move by_group param to project_parameters

### DIFF
--- a/R/load_config.R
+++ b/R/load_config.R
@@ -63,8 +63,8 @@ get_region_select <- function(params) {
   params[["project_parameters"]][["region_select"]]
 }
 
-get_aggregate_alignment_metric_by_group <- function(params) {
-  params[["aggregate_alignment_metric"]][["by_group"]]
+get_by_group <- function(params) {
+  params[["project_parameters"]][["by_group"]]
 }
 
 get_match_priority <- function(params) {

--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -33,7 +33,7 @@ plot_aggregate_loanbooks <- function(config) {
     output_path_aggregated <- file.path(output_path, sector_split_type_select, "aggregated")
   }
 
-  by_group <- get_aggregate_alignment_metric_by_group(config)
+  by_group <- get_by_group(config)
   by_group <- check_and_prepare_by_group(by_group)
 
   dir.create(output_path_aggregated, recursive = TRUE, showWarnings = FALSE)

--- a/R/run_aggregate_alignment_metric.R
+++ b/R/run_aggregate_alignment_metric.R
@@ -26,7 +26,7 @@ run_aggregate_alignment_metric <- function(config) {
   start_year <- get_start_year(config)
   time_frame <- get_time_frame(config)
 
-  by_group <- get_aggregate_alignment_metric_by_group(config)
+  by_group <- get_by_group(config)
   by_group <- check_and_prepare_by_group(by_group)
 
   # load input data----

--- a/R/run_calculate_loanbook_coverage.R
+++ b/R/run_calculate_loanbook_coverage.R
@@ -9,7 +9,7 @@ run_calculate_loanbook_coverage <- function(config) {
   scenario_source_input <- get_scenario_source(config)
   start_year <- get_start_year(config)
 
-  by_group <- get_aggregate_alignment_metric_by_group(config)
+  by_group <- get_by_group(config)
   by_group <- check_and_prepare_by_group(by_group)
   by_group_ext <- if (is.null(by_group)) { "_meta" } else { paste0("_", by_group) }
 

--- a/R/run_calculate_match_success_rate.R
+++ b/R/run_calculate_match_success_rate.R
@@ -9,7 +9,7 @@ run_calculate_match_success_rate <- function(config) {
     path_own_sector_classification <- get_manual_sector_classification_path(config)
   }
 
-  by_group <- get_aggregate_alignment_metric_by_group(config)
+  by_group <- get_by_group(config)
   by_group <- check_and_prepare_by_group(by_group)
   by_group_ext <- if (is.null(by_group)) { "_meta" } else { paste0("_", by_group) }
 

--- a/R/run_pacta.R
+++ b/R/run_pacta.R
@@ -39,7 +39,7 @@ run_pacta <- function(config) {
 
   dir.create(output_path_standard, recursive = TRUE, showWarnings = FALSE)
 
-  by_group <- get_aggregate_alignment_metric_by_group(config)
+  by_group <- get_by_group(config)
   by_group <- check_and_prepare_by_group(by_group)
   by_group_ext <- if (is.null(by_group)) { "_meta" } else { paste0("_", by_group) }
 

--- a/example.config.yml
+++ b/example.config.yml
@@ -18,6 +18,7 @@ default:
     # the scenario in use
     start_year: 2022
     time_frame: 5
+    by_group: "group_id"
   sector_split:
     apply_sector_split: TRUE
     sector_split_type: "equal_weights"
@@ -47,5 +48,3 @@ default:
     plot_height: 8
     plot_units: "in"
     plot_resolution: 300
-  aggregate_alignment_metric:
-    by_group: "group_id"

--- a/vignettes/config_yml.Rmd
+++ b/vignettes/config_yml.Rmd
@@ -134,6 +134,7 @@ A full example `project_parameters`{.yaml} section might look like:
     region_select: "global"
     start_year: 2022
     time_frame: 5
+    by_group: "group_id"
 ```
 
 #### scenario_source
@@ -174,6 +175,14 @@ A full example `project_parameters`{.yaml} section might look like:
 
 ```yaml
     time_frame: 5
+```
+
+#### by_group
+
+`by_group`{.yaml} allows specifying the level of disaggregation to be used in the analysis. It determines the variable along which the loan books are grouped and thus the dimension by which to compare the PACTA calculations. For example, one may want to calculate system-wide results without disaggregation, using `NULL`{.yaml} or one may want to analyse alignment along bank specific traits, such as `"group_id"`{.yaml} or `"bank_type"`{.yaml}. It can be `NULL`{.yaml} or a character vector of length 1. If it is not `NULL`{.yaml}, the indicated name must be a variable that is provided in the input loan books and it must be complete (`"group_id"` is automatically created when reading in the loan books, so the user does not have to add it to the raw loan books). If the provided character string is `"NULL"`{.yaml}, it will be treated as `NULL`{.yaml}. As an example:
+
+```yaml
+    by_group: "group_id"
 ```
 
 ## sector_split:
@@ -438,21 +447,4 @@ A full example `match_success_rate`{.yaml} section might look like:
 
 ```yaml
     plot_resolution: 300
-```
-
-## aggregate_alignment_metric:
-
-A full example `aggregate_alignment_metric`{.yaml} section might look like:
-
-```yaml
-  aggregate_alignment_metric:
-    by_group: "group_id"
-```
-
-#### by_group
-
-`by_group`{.yaml} allows specifying the level of disaggregation to be used in the analysis. It determines the variable along which the loan books are grouped and thus the dimension by which to compare the PACTA calculations. For example, one may want to calculate system-wide results without disaggregation, using `NULL`{.yaml} or one may want to analyse alignment along bank specific traits, such as `"group_id"`{.yaml} or `"bank_type"`{.yaml}. It can be `NULL`{.yaml} or a character vector of length 1. If it is not `NULL`{.yaml}, the indicated name must be a variable that is provided in the input loan books and it must be complete (`"group_id"` is automatically created when reading in the loan books, so the user does not have to add it to the raw loan books). If the provided character string is `"NULL"`{.yaml}, it will be treated as `NULL`{.yaml}. As an example:
-
-```yaml
-    by_group: "group_id"
 ```


### PR DESCRIPTION
closes #130 

- moves parameter `by_group` from `aggregate_alignment_metric` section to` project_parameters` section in `config.yml`
- removes `aggregate_alignment_metric` section entirely, as there are no other parameters left in this section, renames `get_aggregate_alignment_metric_by_group()` to `get_by_group()` to reflect the move
- updates vignette `config_yml.Rmd`, `example.config.yml`