### PR TITLE
use prepared abcd in matching

### DIFF
--- a/R/run_match_prioritize.R
+++ b/R/run_match_prioritize.R
@@ -2,8 +2,7 @@ run_match_prioritize <- function(config) {
   config <- load_config(config)
 
   dir_matched <- get_matched_dir(config)
-  path_abcd <- get_abcd_path(config)
-  sheet_abcd <- get_abcd_sheet(config)
+  abcd_dir <- get_abcd_dir(config)
 
   match_prio_priority <- get_match_priority(config)
 
@@ -11,6 +10,10 @@ run_match_prioritize <- function(config) {
   sector_split_type_select <- get_sector_split_type(config)
 
   # validate config values----
+  stop_if_not_length(abcd_dir, 1L)
+  stop_if_not_inherits(abcd_dir, "character")
+  stop_if_dir_not_found(abcd_dir, desc = "ABCD data")
+
   stop_if_not_length(dir_matched, 1L)
   stop_if_not_inherits(dir_matched, "character")
   stop_if_dir_not_found(dir_matched, desc = "Matched loanbook")
@@ -62,9 +65,11 @@ run_match_prioritize <- function(config) {
       col_select = dplyr::all_of(col_select_companies_sector_split)
     )
 
-    # TODO: better use prepared abcd?
-    abcd <- read_abcd_raw(path_abcd, sheet_abcd)
-    stop_if_not_expected_columns(abcd, cols_abcd, desc = "ABCD")
+    abcd <- readr::read_csv(
+      file.path(abcd_dir, "abcd_final.csv"),
+      col_select = dplyr::all_of(cols_abcd),
+      col_types = col_types_abcd_final
+    )
   }
 
   # prioritize and save files----

--- a/R/run_match_prioritize.R
+++ b/R/run_match_prioritize.R
@@ -13,7 +13,7 @@ run_match_prioritize <- function(config) {
   stop_if_not_length(abcd_dir, 1L)
   stop_if_not_inherits(abcd_dir, "character")
   stop_if_dir_not_found(abcd_dir, desc = "ABCD data")
-
+  stop_if_file_not_found(file.path(abcd_dir, "abcd_final.csv"), desc = "ABCD final")
   stop_if_not_length(dir_matched, 1L)
   stop_if_not_inherits(dir_matched, "character")
   stop_if_dir_not_found(dir_matched, desc = "Matched loanbook")

--- a/R/run_matching.R
+++ b/R/run_matching.R
@@ -25,6 +25,7 @@ run_matching <- function(config) {
   stop_if_not_length(abcd_dir, 1L)
   stop_if_not_inherits(abcd_dir, "character")
   stop_if_dir_not_found(abcd_dir, desc = "ABCD data")
+  stop_if_file_not_found(file.path(abcd_dir, "abcd_final.csv"), desc = "ABCD final")
 
   stop_if_not_length(dir_matched, 1L)
   stop_if_not_inherits(dir_matched, "character")

--- a/R/run_matching.R
+++ b/R/run_matching.R
@@ -2,8 +2,7 @@ run_matching <- function(config) {
   config <- load_config(config)
 
   dir_raw <- get_raw_dir(config)
-  path_abcd <- get_abcd_path(config)
-  sheet_abcd <- get_abcd_sheet(config)
+  abcd_dir <- get_abcd_dir(config)
   dir_matched <- get_matched_dir(config)
 
   matching_by_sector <- get_match_by_sector(config)
@@ -23,9 +22,9 @@ run_matching <- function(config) {
   stop_if_not_inherits(dir_raw, "character")
   stop_if_dir_not_found(dir_raw, desc = "Raw loanbook")
 
-  stop_if_not_length(path_abcd, 1L)
-  stop_if_not_inherits(path_abcd, "character")
-  stop_if_file_not_found(path_abcd, desc = "ABCD data")
+  stop_if_not_length(abcd_dir, 1L)
+  stop_if_not_inherits(abcd_dir, "character")
+  stop_if_dir_not_found(abcd_dir, desc = "ABCD data")
 
   stop_if_not_length(dir_matched, 1L)
   stop_if_not_inherits(dir_matched, "character")
@@ -64,8 +63,11 @@ run_matching <- function(config) {
   # load data----
 
   ## load abcd----
-  abcd <- read_abcd_raw(path_abcd, sheet_abcd)
-  stop_if_not_expected_columns(abcd, cols_abcd, desc = "ABCD")
+  abcd <- readr::read_csv(
+    file.path(abcd_dir, "abcd_final.csv"),
+    col_select = dplyr::all_of(cols_abcd),
+    col_types = col_types_abcd_final
+  )
 
   ## optionally load manual classification system----
   if (matching_use_manual_sector_classification) {


### PR DESCRIPTION
closes #14 

- `run_matching()` and `run_match_prioritize()` now both use the `abcd_final.csv` as input for the abcd, instead of the raw abcd file
- this means that `abcd_final` now simply has to be prepared once using `prepare_abcd()` as the very first step of the analysis and all following functions expect that same data set
- this is a prerequisite for implementing the information architecture as agreed upon in https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/11852