### PR TITLE
don't use external vector in "selection"

### DIFF
--- a/R/run_calculate_match_success_rate.R
+++ b/R/run_calculate_match_success_rate.R
@@ -450,7 +450,7 @@ prep_match_success_rate <- function(data,
     ) %>%
     tidyr::pivot_longer(
       cols = -c(
-        by_group,
+        dplyr::all_of(by_group),
         "sector",
         "matched"
       ),


### PR DESCRIPTION
Not sure if this is the best or most appropriate solution, but this seems to avoid this warning I was getting while writing tests...

```
Warning (test-prioritise_and_diagnose.R:49:3): 
Using an external vector in selections was deprecated in tidyselect 1.1.0.
i Please use `all_of()` or `any_of()` instead.
  # Was:
  data %>% select(by_group)

  # Now:
  data %>% select(all_of(by_group))

See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
Backtrace:
     ▆
  1. ├─testthat::expect_no_error(prioritise_and_diagnose(config)) at test-prioritise_and_diagnose.R:49:3
  2. │ └─testthat:::expect_no_(...)
  3. │   └─testthat:::quasi_capture(enquo(object), NULL, capture)
  4. │     ├─testthat (local) .capture(...)
  5. │     │ └─rlang::try_fetch(...)
  6. │     │   ├─base::tryCatch(...)
  7. │     │   │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
  8. │     │   │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
  9. │     │   │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
 10. │     │   └─base::withCallingHandlers(...)
 11. │     └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
 12. ├─pacta.multi.loanbook::prioritise_and_diagnose(config)
 13. │ └─pacta.multi.loanbook:::run_calculate_match_success_rate(config) at pacta.multi.loanbook/R/prioritise_and_diagnose.R:23:3
 14. │   └─pacta.multi.loanbook:::prep_match_success_rate(...) at pacta.multi.loanbook/R/run_calculate_match_success_rate.R:157:3
 15. │     └─... %>% ... at pacta.multi.loanbook/R/run_calculate_match_success_rate.R:447:3
 16. ├─dplyr::mutate(...)
 17. ├─tidyr::pivot_longer(...)
 18. └─tidyr:::pivot_longer.data.frame(...)
 19.   └─tidyr::build_longer_spec(...)
 20.     └─tidyselect::eval_select(...)
 21.       └─tidyselect:::eval_select_impl(...)
 22.         ├─tidyselect:::with_subscript_errors(...)
 23.         │ └─base::withCallingHandlers(...)
 24.         └─tidyselect:::vars_select_eval(...)
 25.           └─tidyselect:::walk_data_tree(expr, data_mask, context_mask)
 26.             └─tidyselect:::eval_minus(expr, data_mask, context_mask, error_call)
 27.               └─tidyselect:::eval_bang(expr, data_mask, context_mask)
 28.                 └─tidyselect:::walk_data_tree(expr[[2]], data_mask, context_mask)
 29.                   └─tidyselect:::eval_c(expr, data_mask, context_mask)
 30.                     └─tidyselect:::reduce_sels(node, data_mask, context_mask, init = init)
 31.                       └─tidyselect:::walk_data_tree(new, data_mask, context_mask)
 32.                         └─tidyselect:::eval_sym(expr, data_mask, context_mask)
```