### PR TITLE
check that required input files for plots are avaiable or skip

### DIFF
--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -139,7 +139,7 @@ plot_aggregate_loanbooks <- function(config) {
   ### sankey plot----
   # TODO: when benchmarks get re-introduced, they need to be removed here
   # Plot sankey plot of financial flows scenario alignment - examples
-  if (length(by_group) <= 1 & !is.null(company_aggregated_alignment_net)) {
+  if (!is.null(company_aggregated_alignment_net)) {
     data_sankey_sector <- prep_sankey(
       company_aggregated_alignment_net,
       region = "global",
@@ -174,7 +174,7 @@ plot_aggregate_loanbooks <- function(config) {
     print("Sankey plot (by sector) cannot be generated. Skipping!")
   }
 
-  if (length(by_group) <= 1 & !is.null(company_aggregated_alignment_net)) {
+  if (!is.null(company_aggregated_alignment_net)) {
     data_sankey_company_sector <- prep_sankey(
       company_aggregated_alignment_net,
       region = "global",
@@ -214,52 +214,52 @@ plot_aggregate_loanbooks <- function(config) {
   region_scatter_alignment_exposure <- region_select
   currency <- unique(company_aggregated_alignment_net[["loan_size_outstanding_currency"]])
 
-  if (length(by_group) <= 1 & !is.null(loanbook_exposure_aggregated_alignment_net)) {
-      if (
-        nrow(loanbook_exposure_aggregated_alignment_net) > 0
-      ) {
-          data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
-            prep_scatter_alignment_exposure(
-              year = year_scatter_alignment_exposure,
-              region = region_scatter_alignment_exposure,
-              scenario = scenario_select,
-              group_var = by_group,
-              exclude_groups = "benchmark"
-            )
-
-          if (is.null(by_group)) {
-            output_file_alignment_exposure <- "scatter_alignment_exposure"
-          } else {
-            output_file_alignment_exposure <- glue::glue("scatter_alignment_exposure_{by_group}")
-          }
-
-          data_scatter_alignment_exposure %>%
-            readr::write_csv(
-              file = file.path(
-                output_analysis_aggregated_dir,
-                glue::glue("data_{output_file_alignment_exposure}.csv")
-              ),
-              na = ""
-            )
-
-          plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
-            plot_scatter_alignment_exposure(
-              floor_outliers = -1,
-              cap_outliers = 1,
-              group_var = by_group,
-              currency = currency
-            )
-
-          ggplot2::ggsave(
-            filename = glue::glue("plot_{output_file_alignment_exposure}.png"),
-            path = output_analysis_aggregated_dir,
-            width = 8,
-            height = 5,
-            dpi = 300,
-            units = "in",
+  if (!is.null(loanbook_exposure_aggregated_alignment_net)) {
+    if (
+      nrow(loanbook_exposure_aggregated_alignment_net) > 0
+    ) {
+        data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
+          prep_scatter_alignment_exposure(
+            year = year_scatter_alignment_exposure,
+            region = region_scatter_alignment_exposure,
+            scenario = scenario_select,
+            group_var = by_group,
+            exclude_groups = "benchmark"
           )
-      }
-    } else {
+
+        if (is.null(by_group)) {
+          output_file_alignment_exposure <- "scatter_alignment_exposure"
+        } else {
+          output_file_alignment_exposure <- glue::glue("scatter_alignment_exposure_{by_group}")
+        }
+
+        data_scatter_alignment_exposure %>%
+          readr::write_csv(
+            file = file.path(
+              output_analysis_aggregated_dir,
+              glue::glue("data_{output_file_alignment_exposure}.csv")
+            ),
+            na = ""
+          )
+
+        plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
+          plot_scatter_alignment_exposure(
+            floor_outliers = -1,
+            cap_outliers = 1,
+            group_var = by_group,
+            currency = currency
+          )
+
+        ggplot2::ggsave(
+          filename = glue::glue("plot_{output_file_alignment_exposure}.png"),
+          path = output_analysis_aggregated_dir,
+          width = 8,
+          height = 5,
+          dpi = 300,
+          units = "in",
+        )
+    }
+  } else {
     print("Scatter plot exposure by alignment cannot be generated. Skipping!")
   }
 
@@ -269,7 +269,7 @@ plot_aggregate_loanbooks <- function(config) {
   data_level_group <- "group_var"
   # automotive
   sector_scatter <- "automotive"
-  if (length(by_group) <= 1 &
+  if (
     !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
     !is.null(loanbook_exposure_aggregated_alignment_net)
   ) {
@@ -326,9 +326,9 @@ plot_aggregate_loanbooks <- function(config) {
 
   # power
   sector_scatter <- "power"
-  if (length(by_group) <= 1 &
-      !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
-      !is.null(loanbook_exposure_aggregated_alignment_net)
+  if (
+    !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
+    !is.null(loanbook_exposure_aggregated_alignment_net)
   ) {
     if (
       nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
@@ -387,7 +387,10 @@ plot_aggregate_loanbooks <- function(config) {
   # TODO: Note that this implies that no groups across different .by variables
   # should have the same values, as this will confuse output directories
 
-  if (length(by_group) == 1 & !is.null(loanbook_exposure_aggregated_alignment_net)) {
+  if (
+    length(by_group) == 1 &
+    !is.null(loanbook_exposure_aggregated_alignment_net)
+  ) {
     dirs_for_by_group <- loanbook_exposure_aggregated_alignment_net %>%
       dplyr::filter(
         !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
@@ -413,7 +416,10 @@ plot_aggregate_loanbooks <- function(config) {
   # automotive
   sector_scatter <- "automotive"
 
-  if (length(by_group) == 1 & !is.null(company_aggregated_alignment_bo_po)) {
+  if (
+    length(by_group) == 1 &
+    !is.null(company_aggregated_alignment_bo_po)
+  ) {
     unique_by_group <- company_aggregated_alignment_bo_po %>%
       dplyr::filter(
         .data[["sector"]] == .env[["sector_scatter"]],
@@ -476,7 +482,10 @@ plot_aggregate_loanbooks <- function(config) {
   # power
   sector_scatter <- "power"
 
-  if (length(by_group) == 1 & !is.null(company_aggregated_alignment_bo_po)) {
+  if (
+    length(by_group) == 1 &
+    !is.null(company_aggregated_alignment_bo_po)
+  ) {
     unique_by_group <- company_aggregated_alignment_bo_po %>%
       dplyr::filter(
         .data[["sector"]] == .env[["sector_scatter"]],

--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -63,13 +63,11 @@ plot_aggregate_loanbooks <- function(config) {
   )
   col_select_company_aggregated_alignment <- c(by_group, names(col_types_company_aggregated_alignment[["cols"]]))
 
-  if (file.exists(file.path(output_analysis_aggregated_dir, glue::glue("company_exposure_net_aggregate_alignment{file_by_group}.csv")))) {
+  path_company_exposure_net_aggregate_alignment <- file.path(output_analysis_aggregated_dir, glue::glue("company_exposure_net_aggregate_alignment{file_by_group}.csv"))
+  if (file.exists(path_company_exposure_net_aggregate_alignment)) {
     company_aggregated_alignment_net  <-
       readr::read_csv(
-        file = file.path(
-          output_analysis_aggregated_dir,
-          glue::glue("company_exposure_net_aggregate_alignment{file_by_group}.csv")
-        ),
+        file = path_company_exposure_net_aggregate_alignment,
         col_types = col_types_company_aggregated_alignment,
         col_select = dplyr::all_of(col_select_company_aggregated_alignment)
       )
@@ -77,13 +75,11 @@ plot_aggregate_loanbooks <- function(config) {
     company_aggregated_alignment_net <- NULL
   }
 
-  if (file.exists(file.path(output_analysis_aggregated_dir, glue::glue("company_exposure_bo_po_aggregate_alignment{file_by_group}.csv")))) {
+  patch_company_exposure_bo_po_aggregate_alignment <- file.path(output_analysis_aggregated_dir, glue::glue("company_exposure_bo_po_aggregate_alignment{file_by_group}.csv"))
+  if (file.exists(patch_company_exposure_bo_po_aggregate_alignment)) {
     company_aggregated_alignment_bo_po <-
       readr::read_csv(
-        file = file.path(
-          output_analysis_aggregated_dir,
-          glue::glue("company_exposure_bo_po_aggregate_alignment{file_by_group}.csv")
-        ),
+        file = patch_company_exposure_bo_po_aggregate_alignment,
         col_types = col_types_company_aggregated_alignment,
         col_select = dplyr::all_of(col_select_company_aggregated_alignment)
       )
@@ -92,13 +88,11 @@ plot_aggregate_loanbooks <- function(config) {
   }
 
   ## loanbook level results----
-  if (file.exists(file.path(output_analysis_aggregated_dir, glue::glue("loanbook_exposure_bo_po_aggregate_alignment{file_by_group}.csv")))) {
+  path_loanbook_exposure_bo_po_aggregate_alignment <- file.path(output_analysis_aggregated_dir, glue::glue("loanbook_exposure_bo_po_aggregate_alignment{file_by_group}.csv"))
+  if (file.exists(path_loanbook_exposure_bo_po_aggregate_alignment)) {
     loanbook_exposure_aggregated_alignment_bo_po <-
       readr::read_csv(
-        file = file.path(
-          output_analysis_aggregated_dir,
-          glue::glue("loanbook_exposure_bo_po_aggregate_alignment{file_by_group}.csv")
-        ),
+        file = path_loanbook_exposure_bo_po_aggregate_alignment,
         col_types = readr::cols(
           scenario = "c",
           region = "c",
@@ -116,13 +110,11 @@ plot_aggregate_loanbooks <- function(config) {
     loanbook_exposure_aggregated_alignment_bo_po <- NULL
   }
 
-  if (file.exists(file.path(output_analysis_aggregated_dir, glue::glue("loanbook_exposure_net_aggregate_alignment{file_by_group}.csv")))) {
+  path_loanbook_exposure_net_aggregate_alignment <- file.path(output_analysis_aggregated_dir, glue::glue("loanbook_exposure_net_aggregate_alignment{file_by_group}.csv"))
+  if (file.exists(path_loanbook_exposure_net_aggregate_alignment)) {
     loanbook_exposure_aggregated_alignment_net <-
       readr::read_csv(
-        file = file.path(
-          output_analysis_aggregated_dir,
-          glue::glue("loanbook_exposure_net_aggregate_alignment{file_by_group}.csv")
-        ),
+        file = path_loanbook_exposure_net_aggregate_alignment,
         col_types = readr::cols(
           scenario = "c",
           region = "c",

--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -139,18 +139,14 @@ plot_aggregate_loanbooks <- function(config) {
   ### sankey plot----
   # TODO: when benchmarks get re-introduced, they need to be removed here
   # Plot sankey plot of financial flows scenario alignment - examples
-  if (length(by_group) <= 1) {
-    if (!is.null(company_aggregated_alignment_net)) {
-      data_sankey_sector <- prep_sankey(
-        company_aggregated_alignment_net,
-        region = "global",
-        year = start_year + time_frame_select,
-        group_var = by_group,
-        middle_node = "sector"
-      )
-    } else {
-      data_sankey_sector <- NULL
-    }
+  if (length(by_group) <= 1 & !is.null(company_aggregated_alignment_net)) {
+    data_sankey_sector <- prep_sankey(
+      company_aggregated_alignment_net,
+      region = "global",
+      year = start_year + time_frame_select,
+      group_var = by_group,
+      middle_node = "sector"
+    )
 
     if (is.null(by_group)) {
       output_file_sankey_sector <- "sankey_sector"
@@ -158,41 +154,35 @@ plot_aggregate_loanbooks <- function(config) {
       output_file_sankey_sector <- glue::glue("sankey_sector_{by_group}")
     }
 
-    if (!is.null(data_sankey_sector)) {
-      data_sankey_sector %>%
-        readr::write_csv(
-          file = file.path(
-            output_analysis_aggregated_dir,
-            glue::glue("data_{output_file_sankey_sector}.csv")
-          ),
-          na = ""
-        )
-
-      plot_sankey(
-        data_sankey_sector,
-        group_var = by_group,
-        save_png_to = path.expand(output_analysis_aggregated_dir),
-        png_name = glue::glue("plot_{output_file_sankey_sector}.png"),
-        nodes_order_from_data = TRUE
+    data_sankey_sector %>%
+      readr::write_csv(
+        file = file.path(
+          output_analysis_aggregated_dir,
+          glue::glue("data_{output_file_sankey_sector}.csv")
+        ),
+        na = ""
       )
-    }
+
+    plot_sankey(
+      data_sankey_sector,
+      group_var = by_group,
+      save_png_to = path.expand(output_analysis_aggregated_dir),
+      png_name = glue::glue("plot_{output_file_sankey_sector}.png"),
+      nodes_order_from_data = TRUE
+    )
   } else {
-    print("Sankey plot cannot process more than one group_var at a time. Skipping!")
+    print("Sankey plot (by sector) cannot be generated. Skipping!")
   }
 
-  if (length(by_group) <= 1) {
-    if (!is.null(company_aggregated_alignment_net)) {
-      data_sankey_company_sector <- prep_sankey(
-        company_aggregated_alignment_net,
-        region = "global",
-        year = start_year + time_frame_select,
-        group_var = by_group,
-        middle_node = "name_abcd",
-        middle_node2 = "sector"
-      )
-    } else {
-      data_sankey_company_sector <- NULL
-    }
+  if (length(by_group) <= 1 & !is.null(company_aggregated_alignment_net)) {
+    data_sankey_company_sector <- prep_sankey(
+      company_aggregated_alignment_net,
+      region = "global",
+      year = start_year + time_frame_select,
+      group_var = by_group,
+      middle_node = "name_abcd",
+      middle_node2 = "sector"
+    )
 
     if (is.null(by_group)) {
       output_file_sankey_company_sector <- "sankey_company_sector"
@@ -200,84 +190,77 @@ plot_aggregate_loanbooks <- function(config) {
       output_file_sankey_company_sector <- glue::glue("sankey_company_sector_{by_group}")
     }
 
-    if (!is.null(data_sankey_company_sector)) {
-      data_sankey_company_sector %>%
-        readr::write_csv(
-          file = file.path(
-            output_analysis_aggregated_dir,
-            glue::glue("data_{output_file_sankey_company_sector}.csv")
-          ),
-          na = ""
-        )
-
-      plot_sankey(
-        data_sankey_company_sector,
-        group_var = by_group,
-        save_png_to = path.expand(output_analysis_aggregated_dir),
-        png_name = glue::glue("plot_{output_file_sankey_company_sector}.png")
+    data_sankey_company_sector %>%
+      readr::write_csv(
+        file = file.path(
+          output_analysis_aggregated_dir,
+          glue::glue("data_{output_file_sankey_company_sector}.csv")
+        ),
+        na = ""
       )
-    } else {
-      print("Sankey plot cannot be generated because of missing inputs. Skipping!")
-    }
+
+    plot_sankey(
+      data_sankey_company_sector,
+      group_var = by_group,
+      save_png_to = path.expand(output_analysis_aggregated_dir),
+      png_name = glue::glue("plot_{output_file_sankey_company_sector}.png")
+    )
   } else {
-    print("Sankey plot cannot process more than one group_var at a time. Skipping!")
+    print("Sankey plot (by sector and company) cannot be generated. Skipping!")
   }
 
   ### scatter plot alignment by exposure and sector comparison----
   year_scatter_alignment_exposure <- start_year + time_frame_select
   region_scatter_alignment_exposure <- region_select
   currency <- unique(company_aggregated_alignment_net[["loan_size_outstanding_currency"]])
-  if (length(by_group) <= 1) {
-    if (!is.null(loanbook_exposure_aggregated_alignment_net)) {
+
+  if (length(by_group) <= 1 & !is.null(loanbook_exposure_aggregated_alignment_net)) {
       if (
         nrow(loanbook_exposure_aggregated_alignment_net) > 0
       ) {
-        data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
-          prep_scatter_alignment_exposure(
-            year = year_scatter_alignment_exposure,
-            region = region_scatter_alignment_exposure,
-            scenario = scenario_select,
-            group_var = by_group,
-            exclude_groups = "benchmark"
+          data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
+            prep_scatter_alignment_exposure(
+              year = year_scatter_alignment_exposure,
+              region = region_scatter_alignment_exposure,
+              scenario = scenario_select,
+              group_var = by_group,
+              exclude_groups = "benchmark"
+            )
+
+          if (is.null(by_group)) {
+            output_file_alignment_exposure <- "scatter_alignment_exposure"
+          } else {
+            output_file_alignment_exposure <- glue::glue("scatter_alignment_exposure_{by_group}")
+          }
+
+          data_scatter_alignment_exposure %>%
+            readr::write_csv(
+              file = file.path(
+                output_analysis_aggregated_dir,
+                glue::glue("data_{output_file_alignment_exposure}.csv")
+              ),
+              na = ""
+            )
+
+          plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
+            plot_scatter_alignment_exposure(
+              floor_outliers = -1,
+              cap_outliers = 1,
+              group_var = by_group,
+              currency = currency
+            )
+
+          ggplot2::ggsave(
+            filename = glue::glue("plot_{output_file_alignment_exposure}.png"),
+            path = output_analysis_aggregated_dir,
+            width = 8,
+            height = 5,
+            dpi = 300,
+            units = "in",
           )
-
-        if (is.null(by_group)) {
-          output_file_alignment_exposure <- "scatter_alignment_exposure"
-        } else {
-          output_file_alignment_exposure <- glue::glue("scatter_alignment_exposure_{by_group}")
-        }
-
-        data_scatter_alignment_exposure %>%
-          readr::write_csv(
-            file = file.path(
-              output_analysis_aggregated_dir,
-              glue::glue("data_{output_file_alignment_exposure}.csv")
-            ),
-            na = ""
-          )
-
-        plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
-          plot_scatter_alignment_exposure(
-            floor_outliers = -1,
-            cap_outliers = 1,
-            group_var = by_group,
-            currency = currency
-          )
-
-        ggplot2::ggsave(
-          filename = glue::glue("plot_{output_file_alignment_exposure}.png"),
-          path = output_analysis_aggregated_dir,
-          width = 8,
-          height = 5,
-          dpi = 300,
-          units = "in",
-        )
       }
     } else {
-      print("Scatter plot exposure by alignment cannot be generated, because of missing input files. Skipping!")
-    }
-  } else {
-    print("Scatter plot exposure by alignment cannot process more than one group_var at a time. Skipping!")
+    print("Scatter plot exposure by alignment cannot be generated. Skipping!")
   }
 
   ### scatter plot for group level comparison----
@@ -286,128 +269,116 @@ plot_aggregate_loanbooks <- function(config) {
   data_level_group <- "group_var"
   # automotive
   sector_scatter <- "automotive"
-  if (length(by_group) <= 1) {
+  if (length(by_group) <= 1 &
+    !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
+    !is.null(loanbook_exposure_aggregated_alignment_net)
+  ) {
     if (
-      !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
-      !is.null(loanbook_exposure_aggregated_alignment_net)
+      nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
+      nrow(loanbook_exposure_aggregated_alignment_net) > 0
     ) {
-      if (
-        nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
-        nrow(loanbook_exposure_aggregated_alignment_net) > 0
-      ) {
-        data_scatter_automotive_group <- prep_scatter(
-          loanbook_exposure_aggregated_alignment_bo_po,
-          loanbook_exposure_aggregated_alignment_net,
-          year = year_scatter,
-          sector = sector_scatter,
-          region = region_scatter,
-          group_var = by_group,
-          data_level = data_level_group
-        )
+      data_scatter_automotive_group <- prep_scatter(
+        loanbook_exposure_aggregated_alignment_bo_po,
+        loanbook_exposure_aggregated_alignment_net,
+        year = year_scatter,
+        sector = sector_scatter,
+        region = region_scatter,
+        group_var = by_group,
+        data_level = data_level_group
+      )
 
-        if (is.null(by_group)) {
-          output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}")
-        } else {
-          output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}_by_{by_group}")
-        }
-
-        data_scatter_automotive_group %>%
-          readr::write_csv(
-            file = file.path(
-              output_analysis_aggregated_dir,
-              glue::glue("data_{output_file_scatter_sector}.csv")
-            ),
-            na = ""
-          )
-
-        plot_scatter(
-          data_scatter_automotive_group,
-          data_level = data_level_group,
-          year = year_scatter,
-          sector = sector_scatter,
-          region = region_scatter,
-          scenario_source = scenario_source_input,
-          scenario = scenario_select
-        )
-        ggplot2::ggsave(
-          filename = glue::glue("plot_{output_file_scatter_sector}.png"),
-          path = output_analysis_aggregated_dir,
-          width = 8,
-          height = 5
-        )
+      if (is.null(by_group)) {
+        output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}")
+      } else {
+        output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}_by_{by_group}")
       }
-    } else {
-      print(
-        glue::glue("Scatter plot BO/PO cannot be generated, because of missing input files. Skipping!")
+
+      data_scatter_automotive_group %>%
+        readr::write_csv(
+          file = file.path(
+            output_analysis_aggregated_dir,
+            glue::glue("data_{output_file_scatter_sector}.csv")
+          ),
+          na = ""
+        )
+
+      plot_scatter(
+        data_scatter_automotive_group,
+        data_level = data_level_group,
+        year = year_scatter,
+        sector = sector_scatter,
+        region = region_scatter,
+        scenario_source = scenario_source_input,
+        scenario = scenario_select
+      )
+      ggplot2::ggsave(
+        filename = glue::glue("plot_{output_file_scatter_sector}.png"),
+        path = output_analysis_aggregated_dir,
+        width = 8,
+        height = 5
       )
     }
   } else {
     print(
-      glue::glue("Scatter plot BO/PO cannot process more than one group_var at a time. Skipping!")
+      glue::glue("Scatter plot BO/PO cannot be generated. Skipping!")
     )
   }
 
   # power
   sector_scatter <- "power"
-  if (length(by_group) <= 1) {
-    if (
+  if (length(by_group) <= 1 &
       !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
       !is.null(loanbook_exposure_aggregated_alignment_net)
+  ) {
+    if (
+      nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
+      nrow(loanbook_exposure_aggregated_alignment_net) > 0
     ) {
-      if (
-        nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
-        nrow(loanbook_exposure_aggregated_alignment_net) > 0
-      ) {
-        data_scatter_power_group <- prep_scatter(
-          loanbook_exposure_aggregated_alignment_bo_po,
-          loanbook_exposure_aggregated_alignment_net,
-          year = year_scatter,
-          sector = sector_scatter,
-          region = region_scatter,
-          group_var = by_group,
-          data_level = data_level_group
-        )
+      data_scatter_power_group <- prep_scatter(
+        loanbook_exposure_aggregated_alignment_bo_po,
+        loanbook_exposure_aggregated_alignment_net,
+        year = year_scatter,
+        sector = sector_scatter,
+        region = region_scatter,
+        group_var = by_group,
+        data_level = data_level_group
+      )
 
-        if (is.null(by_group)) {
-          output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}")
-        } else {
-          output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}_by_{by_group}")
-        }
-
-        data_scatter_power_group %>%
-          readr::write_csv(
-            file = file.path(
-              output_analysis_aggregated_dir,
-              glue::glue("data_{output_file_scatter_sector}.csv")
-            ),
-            na = ""
-          )
-
-        plot_scatter(
-          data_scatter_power_group,
-          data_level = data_level_group,
-          year = year_scatter,
-          sector = sector_scatter,
-          region = region_scatter,
-          scenario_source = scenario_source_input,
-          scenario = scenario_select
-        )
-
-        ggplot2::ggsave(
-          filename = glue::glue("plot_{output_file_scatter_sector}.png"),
-          path = output_analysis_aggregated_dir,
-          width = 8,
-          height = 5
-        )
+      if (is.null(by_group)) {
+        output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}")
+      } else {
+        output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}_by_{by_group}")
       }
-    } else {
-      print(
-        glue::glue("Scatter plot BO/PO cannot be generated, because of missing input files. Skipping!")
+
+      data_scatter_power_group %>%
+        readr::write_csv(
+          file = file.path(
+            output_analysis_aggregated_dir,
+            glue::glue("data_{output_file_scatter_sector}.csv")
+          ),
+          na = ""
+        )
+
+      plot_scatter(
+        data_scatter_power_group,
+        data_level = data_level_group,
+        year = year_scatter,
+        sector = sector_scatter,
+        region = region_scatter,
+        scenario_source = scenario_source_input,
+        scenario = scenario_select
+      )
+
+      ggplot2::ggsave(
+        filename = glue::glue("plot_{output_file_scatter_sector}.png"),
+        path = output_analysis_aggregated_dir,
+        width = 8,
+        height = 5
       )
     }
   } else {
     print(
-      glue::glue("Scatter plot BO/PO cannot process more than one group_var at a time. Skipping!")
+      glue::glue("Scatter plot BO/PO cannot be generated. Skipping!")
     )
   }
 
@@ -416,18 +387,16 @@ plot_aggregate_loanbooks <- function(config) {
   # TODO: Note that this implies that no groups across different .by variables
   # should have the same values, as this will confuse output directories
 
-  if (length(by_group) == 1) {
-    if (!is.null(loanbook_exposure_aggregated_alignment_net)) {
-      dirs_for_by_group <- loanbook_exposure_aggregated_alignment_net %>%
-        dplyr::filter(
-          !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
-        ) %>%
-        dplyr::pull(!!rlang::sym(by_group)) %>%
-        unique()
+  if (length(by_group) == 1 & !is.null(loanbook_exposure_aggregated_alignment_net)) {
+    dirs_for_by_group <- loanbook_exposure_aggregated_alignment_net %>%
+      dplyr::filter(
+        !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
+      ) %>%
+      dplyr::pull(!!rlang::sym(by_group)) %>%
+      unique()
 
-      for (i in dirs_for_by_group) {
-        dir.create(file.path(output_analysis_aggregated_dir, i), recursive = TRUE, showWarnings = FALSE)
-      }
+    for (i in dirs_for_by_group) {
+      dir.create(file.path(output_analysis_aggregated_dir, i), recursive = TRUE, showWarnings = FALSE)
     }
   }
 
@@ -444,138 +413,127 @@ plot_aggregate_loanbooks <- function(config) {
   # automotive
   sector_scatter <- "automotive"
 
-  if (length(by_group) == 1) {
-    if (!is.null(company_aggregated_alignment_bo_po)) {
-      unique_by_group <- company_aggregated_alignment_bo_po %>%
-        dplyr::filter(
-          .data[["sector"]] == .env[["sector_scatter"]],
-          !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
-        ) %>%
-        dplyr::pull(!!rlang::sym(by_group)) %>%
-        unique()
+  if (length(by_group) == 1 & !is.null(company_aggregated_alignment_bo_po)) {
+    unique_by_group <- company_aggregated_alignment_bo_po %>%
+      dplyr::filter(
+        .data[["sector"]] == .env[["sector_scatter"]],
+        !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
+      ) %>%
+      dplyr::pull(!!rlang::sym(by_group)) %>%
+      unique()
 
-      for (i in unique_by_group) {
-        data_scatter_automotive_company_i <- prep_scatter(
-          company_aggregated_alignment_bo_po,
-          company_aggregated_alignment_net,
+    for (i in unique_by_group) {
+      data_scatter_automotive_company_i <- prep_scatter(
+        company_aggregated_alignment_bo_po,
+        company_aggregated_alignment_net,
+        year = year_scatter,
+        sector = sector_scatter,
+        region = region_scatter,
+        group_var = by_group,
+        groups_to_plot = i,
+        data_level = data_level_company
+      )
+
+      if (nrow(data_scatter_automotive_company_i) > 0) {
+        data_scatter_automotive_company_i %>%
+          readr::write_csv(
+            file = file.path(
+              output_analysis_aggregated_dir,
+              i,
+              glue::glue("data_scatter_automotive_company_by_{by_group}_{i}.csv")
+            ),
+            na = ""
+          )
+
+        plot_scatter(
+          data_scatter_automotive_company_i,
+          data_level = data_level_company,
           year = year_scatter,
           sector = sector_scatter,
           region = region_scatter,
-          group_var = by_group,
-          groups_to_plot = i,
-          data_level = data_level_company
+          scenario_source = scenario_source_input,
+          scenario = scenario_select,
+          cap_outliers = 2,
+          floor_outliers = -2
         )
 
-        if (nrow(data_scatter_automotive_company_i) > 0) {
-          data_scatter_automotive_company_i %>%
-            readr::write_csv(
-              file = file.path(
-                output_analysis_aggregated_dir,
-                i,
-                glue::glue("data_scatter_automotive_company_by_{by_group}_{i}.csv")
-              ),
-              na = ""
-            )
-
-          plot_scatter(
-            data_scatter_automotive_company_i,
-            data_level = data_level_company,
-            year = year_scatter,
-            sector = sector_scatter,
-            region = region_scatter,
-            scenario_source = scenario_source_input,
-            scenario = scenario_select,
-            cap_outliers = 2,
-            floor_outliers = -2
-          )
-
-          ggplot2::ggsave(
-            filename = glue::glue("plot_scatter_automotive_company_by_{by_group}_{i}.png"),
-            path = file.path(output_analysis_aggregated_dir, i),
-            width = 8,
-            height = 5
-          )
-        } else {
-          next()
-        }
+        ggplot2::ggsave(
+          filename = glue::glue("plot_scatter_automotive_company_by_{by_group}_{i}.png"),
+          path = file.path(output_analysis_aggregated_dir, i),
+          width = 8,
+          height = 5
+        )
+      } else {
+        next()
       }
-    } else {
-      print(
-        glue::glue("Scatter plot BO/PO cannot be generated at company level, because of missing input files. Skipping!")
-      )
     }
   } else {
     print(
-      glue::glue("Scatter plot BO/PO only available for group_var of length 1. Skipping!")
+      glue::glue("Scatter plot BO/PO cannot be generated at company level. Skipping!")
     )
   }
 
   # power
   sector_scatter <- "power"
 
-  if (length(by_group) == 1) {
-    if (!is.null(company_aggregated_alignment_bo_po)) {
-      unique_by_group <- company_aggregated_alignment_bo_po %>%
-        dplyr::filter(
-          .data[["sector"]] == .env[["sector_scatter"]],
-          !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
-        ) %>%
-        dplyr::pull(!!rlang::sym(by_group)) %>%
-        unique()
+  if (length(by_group) == 1 & !is.null(company_aggregated_alignment_bo_po)) {
+    unique_by_group <- company_aggregated_alignment_bo_po %>%
+      dplyr::filter(
+        .data[["sector"]] == .env[["sector_scatter"]],
+        !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
+      ) %>%
+      dplyr::pull(!!rlang::sym(by_group)) %>%
+      unique()
 
-      for (i in unique_by_group) {
-        data_scatter_power_company_i <- prep_scatter(
-          company_aggregated_alignment_bo_po,
-          company_aggregated_alignment_net,
+    for (i in unique_by_group) {
+      data_scatter_power_company_i <- prep_scatter(
+        company_aggregated_alignment_bo_po,
+        company_aggregated_alignment_net,
+        year = year_scatter,
+        sector = sector_scatter,
+        region = region_scatter,
+        group_var = by_group,
+        groups_to_plot = i,
+        data_level = data_level_company
+      )
+
+      if (nrow(data_scatter_power_company_i) > 0) {
+        data_scatter_power_company_i %>%
+          readr::write_csv(
+            file = file.path(
+              output_analysis_aggregated_dir,
+              i,
+              glue::glue("data_scatter_power_company_by_{by_group}_{i}.csv")
+            ),
+            na = ""
+          )
+
+        plot_scatter(
+          data_scatter_power_company_i,
+          data_level = data_level_company,
           year = year_scatter,
           sector = sector_scatter,
           region = region_scatter,
-          group_var = by_group,
-          groups_to_plot = i,
-          data_level = data_level_company
+          scenario_source = scenario_source_input,
+          scenario = scenario_select,
+          cap_outliers = 2,
+          floor_outliers = -2
         )
 
-        if (nrow(data_scatter_power_company_i) > 0) {
-          data_scatter_power_company_i %>%
-            readr::write_csv(
-              file = file.path(
-                output_analysis_aggregated_dir,
-                i,
-                glue::glue("data_scatter_power_company_by_{by_group}_{i}.csv")
-              ),
-              na = ""
-            )
-
-          plot_scatter(
-            data_scatter_power_company_i,
-            data_level = data_level_company,
-            year = year_scatter,
-            sector = sector_scatter,
-            region = region_scatter,
-            scenario_source = scenario_source_input,
-            scenario = scenario_select,
-            cap_outliers = 2,
-            floor_outliers = -2
-          )
-
-          ggplot2::ggsave(
-            filename = glue::glue("plot_scatter_power_company_by_{by_group}_{i}.png"),
-            path = file.path(output_analysis_aggregated_dir, i),
-            width = 8,
-            height = 5
-          )
-        } else {
-          next()
-        }
+        ggplot2::ggsave(
+          filename = glue::glue("plot_scatter_power_company_by_{by_group}_{i}.png"),
+          path = file.path(output_analysis_aggregated_dir, i),
+          width = 8,
+          height = 5
+        )
+      } else {
+        next()
       }
-    } else {
-      print(
-        glue::glue("Scatter plot BO/PO cannot be generated at company level, because of missing input files. Skipping!")
-      )
     }
   } else {
     print(
-      glue::glue("Scatter plot BO/PO only available for group_var of length 1. Skipping!")
+      glue::glue("Scatter plot BO/PO cannot be generated at company level. Skipping!")
     )
   }
+
 }

--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -22,10 +22,14 @@ plot_aggregate_loanbooks <- function(config) {
   start_year <- get_start_year(config)
   time_frame_select <- get_time_frame(config)
   apply_sector_split <- get_apply_sector_split(config)
-  if (is.null(apply_sector_split)) { apply_sector_split <- FALSE }
+  if (is.null(apply_sector_split)) {
+    apply_sector_split <- FALSE
+  }
   sector_split_type_select <- get_sector_split_type(config)
   remove_inactive_companies <- get_remove_inactive_companies(config)
-  if (is.null(remove_inactive_companies)) { remove_inactive_companies <- FALSE }
+  if (is.null(remove_inactive_companies)) {
+    remove_inactive_companies <- FALSE
+  }
 
   # if a sector split is applied, write results into a directory that states the type
   if (apply_sector_split) {
@@ -65,7 +69,7 @@ plot_aggregate_loanbooks <- function(config) {
 
   path_company_exposure_net_aggregate_alignment <- file.path(output_analysis_aggregated_dir, glue::glue("company_exposure_net_aggregate_alignment{file_by_group}.csv"))
   if (file.exists(path_company_exposure_net_aggregate_alignment)) {
-    company_aggregated_alignment_net  <-
+    company_aggregated_alignment_net <-
       readr::read_csv(
         file = path_company_exposure_net_aggregate_alignment,
         col_types = col_types_company_aggregated_alignment,
@@ -218,46 +222,46 @@ plot_aggregate_loanbooks <- function(config) {
     if (
       nrow(loanbook_exposure_aggregated_alignment_net) > 0
     ) {
-        data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
-          prep_scatter_alignment_exposure(
-            year = year_scatter_alignment_exposure,
-            region = region_scatter_alignment_exposure,
-            scenario = scenario_select,
-            group_var = by_group,
-            exclude_groups = "benchmark"
-          )
-
-        if (is.null(by_group)) {
-          output_file_alignment_exposure <- "scatter_alignment_exposure"
-        } else {
-          output_file_alignment_exposure <- glue::glue("scatter_alignment_exposure_{by_group}")
-        }
-
-        data_scatter_alignment_exposure %>%
-          readr::write_csv(
-            file = file.path(
-              output_analysis_aggregated_dir,
-              glue::glue("data_{output_file_alignment_exposure}.csv")
-            ),
-            na = ""
-          )
-
-        plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
-          plot_scatter_alignment_exposure(
-            floor_outliers = -1,
-            cap_outliers = 1,
-            group_var = by_group,
-            currency = currency
-          )
-
-        ggplot2::ggsave(
-          filename = glue::glue("plot_{output_file_alignment_exposure}.png"),
-          path = output_analysis_aggregated_dir,
-          width = 8,
-          height = 5,
-          dpi = 300,
-          units = "in",
+      data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
+        prep_scatter_alignment_exposure(
+          year = year_scatter_alignment_exposure,
+          region = region_scatter_alignment_exposure,
+          scenario = scenario_select,
+          group_var = by_group,
+          exclude_groups = "benchmark"
         )
+
+      if (is.null(by_group)) {
+        output_file_alignment_exposure <- "scatter_alignment_exposure"
+      } else {
+        output_file_alignment_exposure <- glue::glue("scatter_alignment_exposure_{by_group}")
+      }
+
+      data_scatter_alignment_exposure %>%
+        readr::write_csv(
+          file = file.path(
+            output_analysis_aggregated_dir,
+            glue::glue("data_{output_file_alignment_exposure}.csv")
+          ),
+          na = ""
+        )
+
+      plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
+        plot_scatter_alignment_exposure(
+          floor_outliers = -1,
+          cap_outliers = 1,
+          group_var = by_group,
+          currency = currency
+        )
+
+      ggplot2::ggsave(
+        filename = glue::glue("plot_{output_file_alignment_exposure}.png"),
+        path = output_analysis_aggregated_dir,
+        width = 8,
+        height = 5,
+        dpi = 300,
+        units = "in",
+      )
     }
   } else {
     print("Scatter plot exposure by alignment cannot be generated. Skipping!")
@@ -271,11 +275,11 @@ plot_aggregate_loanbooks <- function(config) {
   sector_scatter <- "automotive"
   if (
     !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
-    !is.null(loanbook_exposure_aggregated_alignment_net)
+      !is.null(loanbook_exposure_aggregated_alignment_net)
   ) {
     if (
       nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
-      nrow(loanbook_exposure_aggregated_alignment_net) > 0
+        nrow(loanbook_exposure_aggregated_alignment_net) > 0
     ) {
       data_scatter_automotive_group <- prep_scatter(
         loanbook_exposure_aggregated_alignment_bo_po,
@@ -328,11 +332,11 @@ plot_aggregate_loanbooks <- function(config) {
   sector_scatter <- "power"
   if (
     !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
-    !is.null(loanbook_exposure_aggregated_alignment_net)
+      !is.null(loanbook_exposure_aggregated_alignment_net)
   ) {
     if (
       nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
-      nrow(loanbook_exposure_aggregated_alignment_net) > 0
+        nrow(loanbook_exposure_aggregated_alignment_net) > 0
     ) {
       data_scatter_power_group <- prep_scatter(
         loanbook_exposure_aggregated_alignment_bo_po,
@@ -389,7 +393,7 @@ plot_aggregate_loanbooks <- function(config) {
 
   if (
     length(by_group) == 1 &
-    !is.null(loanbook_exposure_aggregated_alignment_net)
+      !is.null(loanbook_exposure_aggregated_alignment_net)
   ) {
     dirs_for_by_group <- loanbook_exposure_aggregated_alignment_net %>%
       dplyr::filter(
@@ -418,7 +422,7 @@ plot_aggregate_loanbooks <- function(config) {
 
   if (
     length(by_group) == 1 &
-    !is.null(company_aggregated_alignment_bo_po)
+      !is.null(company_aggregated_alignment_bo_po)
   ) {
     unique_by_group <- company_aggregated_alignment_bo_po %>%
       dplyr::filter(
@@ -484,7 +488,7 @@ plot_aggregate_loanbooks <- function(config) {
 
   if (
     length(by_group) == 1 &
-    !is.null(company_aggregated_alignment_bo_po)
+      !is.null(company_aggregated_alignment_bo_po)
   ) {
     unique_by_group <- company_aggregated_alignment_bo_po %>%
       dplyr::filter(
@@ -544,5 +548,4 @@ plot_aggregate_loanbooks <- function(config) {
       glue::glue("Scatter plot BO/PO cannot be generated at company level. Skipping!")
     )
   }
-
 }

--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -63,69 +63,85 @@ plot_aggregate_loanbooks <- function(config) {
   )
   col_select_company_aggregated_alignment <- c(by_group, names(col_types_company_aggregated_alignment[["cols"]]))
 
-  company_aggregated_alignment_net  <-
-    readr::read_csv(
-      file = file.path(
-        output_analysis_aggregated_dir,
-        glue::glue("company_exposure_net_aggregate_alignment{file_by_group}.csv")
-      ),
-      col_types = col_types_company_aggregated_alignment,
-      col_select = dplyr::all_of(col_select_company_aggregated_alignment)
-    )
+  if (file.exists(file.path(output_analysis_aggregated_dir, glue::glue("company_exposure_net_aggregate_alignment{file_by_group}.csv")))) {
+    company_aggregated_alignment_net  <-
+      readr::read_csv(
+        file = file.path(
+          output_analysis_aggregated_dir,
+          glue::glue("company_exposure_net_aggregate_alignment{file_by_group}.csv")
+        ),
+        col_types = col_types_company_aggregated_alignment,
+        col_select = dplyr::all_of(col_select_company_aggregated_alignment)
+      )
+  } else {
+    company_aggregated_alignment_net <- NULL
+  }
 
-  company_aggregated_alignment_bo_po <-
-    readr::read_csv(
-      file = file.path(
-        output_analysis_aggregated_dir,
-        glue::glue("company_exposure_bo_po_aggregate_alignment{file_by_group}.csv")
-      ),
-      col_types = col_types_company_aggregated_alignment,
-      col_select = dplyr::all_of(col_select_company_aggregated_alignment)
-    )
+  if (file.exists(file.path(output_analysis_aggregated_dir, glue::glue("company_exposure_bo_po_aggregate_alignment{file_by_group}.csv")))) {
+    company_aggregated_alignment_bo_po <-
+      readr::read_csv(
+        file = file.path(
+          output_analysis_aggregated_dir,
+          glue::glue("company_exposure_bo_po_aggregate_alignment{file_by_group}.csv")
+        ),
+        col_types = col_types_company_aggregated_alignment,
+        col_select = dplyr::all_of(col_select_company_aggregated_alignment)
+      )
+  } else {
+    company_aggregated_alignment_bo_po <- NULL
+  }
 
   ## loanbook level results----
-  loanbook_exposure_aggregated_alignment_bo_po <-
-    readr::read_csv(
-      file = file.path(
-        output_analysis_aggregated_dir,
-        glue::glue("loanbook_exposure_bo_po_aggregate_alignment{file_by_group}.csv")
-      ),
-      col_types = readr::cols(
-        scenario = "c",
-        region = "c",
-        sector = "c",
-        year = "i",
-        direction = "c",
-        n_companies = "i",
-        n_companies_aligned = "i",
-        share_companies_aligned = "n",
-        exposure_weighted_net_alignment = "n",
-        .default = "c"
+  if (file.exists(file.path(output_analysis_aggregated_dir, glue::glue("loanbook_exposure_bo_po_aggregate_alignment{file_by_group}.csv")))) {
+    loanbook_exposure_aggregated_alignment_bo_po <-
+      readr::read_csv(
+        file = file.path(
+          output_analysis_aggregated_dir,
+          glue::glue("loanbook_exposure_bo_po_aggregate_alignment{file_by_group}.csv")
+        ),
+        col_types = readr::cols(
+          scenario = "c",
+          region = "c",
+          sector = "c",
+          year = "i",
+          direction = "c",
+          n_companies = "i",
+          n_companies_aligned = "i",
+          share_companies_aligned = "n",
+          exposure_weighted_net_alignment = "n",
+          .default = "c"
+        )
       )
-    )
+  } else {
+    loanbook_exposure_aggregated_alignment_bo_po <- NULL
+  }
 
-  loanbook_exposure_aggregated_alignment_net <-
-    readr::read_csv(
-      file = file.path(
-        output_analysis_aggregated_dir,
-        glue::glue("loanbook_exposure_net_aggregate_alignment{file_by_group}.csv")
-      ),
-      col_types = readr::cols(
-        scenario = "c",
-        region = "c",
-        sector = "c",
-        year = "i",
-        direction = "c",
-        n_companies = "i",
-        n_companies_aligned = "i",
-        share_companies_aligned = "n",
-        exposure_weighted_net_alignment = "n",
-        sum_loan_size_outstanding = "n",
-        sum_exposure_companies_aligned = "n",
-        share_exposure_aligned = "n",
-        .default = "c"
-    )
-  )
+  if (file.exists(file.path(output_analysis_aggregated_dir, glue::glue("loanbook_exposure_net_aggregate_alignment{file_by_group}.csv")))) {
+    loanbook_exposure_aggregated_alignment_net <-
+      readr::read_csv(
+        file = file.path(
+          output_analysis_aggregated_dir,
+          glue::glue("loanbook_exposure_net_aggregate_alignment{file_by_group}.csv")
+        ),
+        col_types = readr::cols(
+          scenario = "c",
+          region = "c",
+          sector = "c",
+          year = "i",
+          direction = "c",
+          n_companies = "i",
+          n_companies_aligned = "i",
+          share_companies_aligned = "n",
+          exposure_weighted_net_alignment = "n",
+          sum_loan_size_outstanding = "n",
+          sum_exposure_companies_aligned = "n",
+          share_exposure_aligned = "n",
+          .default = "c"
+        )
+      )
+  } else {
+    loanbook_exposure_aggregated_alignment_net <- NULL
+  }
 
   # generate plots for system-wide analysis----
   ### sankey plot----
@@ -208,6 +224,8 @@ plot_aggregate_loanbooks <- function(config) {
         save_png_to = path.expand(output_analysis_aggregated_dir),
         png_name = glue::glue("plot_{output_file_sankey_company_sector}.png")
       )
+    } else {
+      print("Sankey plot cannot be generated because of missing inputs. Skipping!")
     }
   } else {
     print("Sankey plot cannot process more than one group_var at a time. Skipping!")
@@ -218,55 +236,57 @@ plot_aggregate_loanbooks <- function(config) {
   region_scatter_alignment_exposure <- region_select
   currency <- unique(company_aggregated_alignment_net[["loan_size_outstanding_currency"]])
   if (length(by_group) <= 1) {
-    if (
-      nrow(loanbook_exposure_aggregated_alignment_net) > 0
-    ) {
-      data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
-        prep_scatter_alignment_exposure(
-          year = year_scatter_alignment_exposure,
-          region = region_scatter_alignment_exposure,
-          scenario = scenario_select,
-          group_var = by_group,
-          exclude_groups = "benchmark"
-        )
+    if (!is.null(loanbook_exposure_aggregated_alignment_net)) {
+      if (
+        nrow(loanbook_exposure_aggregated_alignment_net) > 0
+      ) {
+        data_scatter_alignment_exposure <- loanbook_exposure_aggregated_alignment_net %>%
+          prep_scatter_alignment_exposure(
+            year = year_scatter_alignment_exposure,
+            region = region_scatter_alignment_exposure,
+            scenario = scenario_select,
+            group_var = by_group,
+            exclude_groups = "benchmark"
+          )
 
-      if (is.null(by_group)) {
-        output_file_alignment_exposure <- "scatter_alignment_exposure"
-      } else {
-        output_file_alignment_exposure <- glue::glue("scatter_alignment_exposure_{by_group}")
+        if (is.null(by_group)) {
+          output_file_alignment_exposure <- "scatter_alignment_exposure"
+        } else {
+          output_file_alignment_exposure <- glue::glue("scatter_alignment_exposure_{by_group}")
+        }
+
+        data_scatter_alignment_exposure %>%
+          readr::write_csv(
+            file = file.path(
+              output_analysis_aggregated_dir,
+              glue::glue("data_{output_file_alignment_exposure}.csv")
+            ),
+            na = ""
+          )
+
+        plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
+          plot_scatter_alignment_exposure(
+            floor_outliers = -1,
+            cap_outliers = 1,
+            group_var = by_group,
+            currency = currency
+          )
+
+        ggplot2::ggsave(
+          filename = glue::glue("plot_{output_file_alignment_exposure}.png"),
+          path = output_analysis_aggregated_dir,
+          width = 8,
+          height = 5,
+          dpi = 300,
+          units = "in",
+        )
       }
-
-      data_scatter_alignment_exposure %>%
-        readr::write_csv(
-          file = file.path(
-            output_analysis_aggregated_dir,
-            glue::glue("data_{output_file_alignment_exposure}.csv")
-          ),
-          na = ""
-        )
-
-      plot_scatter_alignment_exposure <- data_scatter_alignment_exposure %>%
-        plot_scatter_alignment_exposure(
-          floor_outliers = -1,
-          cap_outliers = 1,
-          group_var = by_group,
-          currency = currency
-        )
-
-      ggplot2::ggsave(
-        filename = glue::glue("plot_{output_file_alignment_exposure}.png"),
-        path = output_analysis_aggregated_dir,
-        width = 8,
-        height = 5,
-        dpi = 300,
-        units = "in",
-      )
+    } else {
+      print("Scatter plot exposure by alignment cannot be generated, because of missing input files. Skipping!")
     }
   } else {
     print("Scatter plot exposure by alignment cannot process more than one group_var at a time. Skipping!")
   }
-
-
 
   ### scatter plot for group level comparison----
   year_scatter <- 2027
@@ -276,48 +296,57 @@ plot_aggregate_loanbooks <- function(config) {
   sector_scatter <- "automotive"
   if (length(by_group) <= 1) {
     if (
-      nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
-      nrow(loanbook_exposure_aggregated_alignment_net) > 0
+      !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
+      !is.null(loanbook_exposure_aggregated_alignment_net)
     ) {
-      data_scatter_automotive_group <- prep_scatter(
-        loanbook_exposure_aggregated_alignment_bo_po,
-        loanbook_exposure_aggregated_alignment_net,
-        year = year_scatter,
-        sector = sector_scatter,
-        region = region_scatter,
-        group_var = by_group,
-        data_level = data_level_group
-      )
-
-      if (is.null(by_group)) {
-        output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}")
-      } else {
-        output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}_by_{by_group}")
-      }
-
-      data_scatter_automotive_group %>%
-        readr::write_csv(
-          file = file.path(
-            output_analysis_aggregated_dir,
-            glue::glue("data_{output_file_scatter_sector}.csv")
-          ),
-          na = ""
+      if (
+        nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
+        nrow(loanbook_exposure_aggregated_alignment_net) > 0
+      ) {
+        data_scatter_automotive_group <- prep_scatter(
+          loanbook_exposure_aggregated_alignment_bo_po,
+          loanbook_exposure_aggregated_alignment_net,
+          year = year_scatter,
+          sector = sector_scatter,
+          region = region_scatter,
+          group_var = by_group,
+          data_level = data_level_group
         )
 
-      plot_scatter(
-        data_scatter_automotive_group,
-        data_level = data_level_group,
-        year = year_scatter,
-        sector = sector_scatter,
-        region = region_scatter,
-        scenario_source = scenario_source_input,
-        scenario = scenario_select
-      )
-      ggplot2::ggsave(
-        filename = glue::glue("plot_{output_file_scatter_sector}.png"),
-        path = output_analysis_aggregated_dir,
-        width = 8,
-        height = 5
+        if (is.null(by_group)) {
+          output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}")
+        } else {
+          output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}_by_{by_group}")
+        }
+
+        data_scatter_automotive_group %>%
+          readr::write_csv(
+            file = file.path(
+              output_analysis_aggregated_dir,
+              glue::glue("data_{output_file_scatter_sector}.csv")
+            ),
+            na = ""
+          )
+
+        plot_scatter(
+          data_scatter_automotive_group,
+          data_level = data_level_group,
+          year = year_scatter,
+          sector = sector_scatter,
+          region = region_scatter,
+          scenario_source = scenario_source_input,
+          scenario = scenario_select
+        )
+        ggplot2::ggsave(
+          filename = glue::glue("plot_{output_file_scatter_sector}.png"),
+          path = output_analysis_aggregated_dir,
+          width = 8,
+          height = 5
+        )
+      }
+    } else {
+      print(
+        glue::glue("Scatter plot BO/PO cannot be generated, because of missing input files. Skipping!")
       )
     }
   } else {
@@ -330,49 +359,58 @@ plot_aggregate_loanbooks <- function(config) {
   sector_scatter <- "power"
   if (length(by_group) <= 1) {
     if (
-      nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
-      nrow(loanbook_exposure_aggregated_alignment_net) > 0
+      !is.null(loanbook_exposure_aggregated_alignment_bo_po) &
+      !is.null(loanbook_exposure_aggregated_alignment_net)
     ) {
-      data_scatter_power_group <- prep_scatter(
-        loanbook_exposure_aggregated_alignment_bo_po,
-        loanbook_exposure_aggregated_alignment_net,
-        year = year_scatter,
-        sector = sector_scatter,
-        region = region_scatter,
-        group_var = by_group,
-        data_level = data_level_group
-      )
-
-      if (is.null(by_group)) {
-        output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}")
-      } else {
-        output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}_by_{by_group}")
-      }
-
-      data_scatter_power_group %>%
-        readr::write_csv(
-          file = file.path(
-            output_analysis_aggregated_dir,
-            glue::glue("data_{output_file_scatter_sector}.csv")
-          ),
-          na = ""
+      if (
+        nrow(loanbook_exposure_aggregated_alignment_bo_po) > 0 &
+        nrow(loanbook_exposure_aggregated_alignment_net) > 0
+      ) {
+        data_scatter_power_group <- prep_scatter(
+          loanbook_exposure_aggregated_alignment_bo_po,
+          loanbook_exposure_aggregated_alignment_net,
+          year = year_scatter,
+          sector = sector_scatter,
+          region = region_scatter,
+          group_var = by_group,
+          data_level = data_level_group
         )
 
-      plot_scatter(
-        data_scatter_power_group,
-        data_level = data_level_group,
-        year = year_scatter,
-        sector = sector_scatter,
-        region = region_scatter,
-        scenario_source = scenario_source_input,
-        scenario = scenario_select
-      )
+        if (is.null(by_group)) {
+          output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}")
+        } else {
+          output_file_scatter_sector <- glue::glue("scatter_{sector_scatter}_by_{by_group}")
+        }
 
-      ggplot2::ggsave(
-        filename = glue::glue("plot_{output_file_scatter_sector}.png"),
-        path = output_analysis_aggregated_dir,
-        width = 8,
-        height = 5
+        data_scatter_power_group %>%
+          readr::write_csv(
+            file = file.path(
+              output_analysis_aggregated_dir,
+              glue::glue("data_{output_file_scatter_sector}.csv")
+            ),
+            na = ""
+          )
+
+        plot_scatter(
+          data_scatter_power_group,
+          data_level = data_level_group,
+          year = year_scatter,
+          sector = sector_scatter,
+          region = region_scatter,
+          scenario_source = scenario_source_input,
+          scenario = scenario_select
+        )
+
+        ggplot2::ggsave(
+          filename = glue::glue("plot_{output_file_scatter_sector}.png"),
+          path = output_analysis_aggregated_dir,
+          width = 8,
+          height = 5
+        )
+      }
+    } else {
+      print(
+        glue::glue("Scatter plot BO/PO cannot be generated, because of missing input files. Skipping!")
       )
     }
   } else {
@@ -387,15 +425,17 @@ plot_aggregate_loanbooks <- function(config) {
   # should have the same values, as this will confuse output directories
 
   if (length(by_group) == 1) {
-    dirs_for_by_group <- loanbook_exposure_aggregated_alignment_net %>%
-      dplyr::filter(
-        !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
-      ) %>%
-      dplyr::pull(!!rlang::sym(by_group)) %>%
-      unique()
+    if (!is.null(loanbook_exposure_aggregated_alignment_net)) {
+      dirs_for_by_group <- loanbook_exposure_aggregated_alignment_net %>%
+        dplyr::filter(
+          !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
+        ) %>%
+        dplyr::pull(!!rlang::sym(by_group)) %>%
+        unique()
 
-    for (i in dirs_for_by_group) {
-      dir.create(file.path(output_analysis_aggregated_dir, i), recursive = TRUE, showWarnings = FALSE)
+      for (i in dirs_for_by_group) {
+        dir.create(file.path(output_analysis_aggregated_dir, i), recursive = TRUE, showWarnings = FALSE)
+      }
     }
   }
 
@@ -413,58 +453,64 @@ plot_aggregate_loanbooks <- function(config) {
   sector_scatter <- "automotive"
 
   if (length(by_group) == 1) {
-    unique_by_group <- company_aggregated_alignment_bo_po %>%
-      dplyr::filter(
-        .data[["sector"]] == .env[["sector_scatter"]],
-        !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
-      ) %>%
-      dplyr::pull(!!rlang::sym(by_group)) %>%
-      unique()
+    if (!is.null(company_aggregated_alignment_bo_po)) {
+      unique_by_group <- company_aggregated_alignment_bo_po %>%
+        dplyr::filter(
+          .data[["sector"]] == .env[["sector_scatter"]],
+          !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
+        ) %>%
+        dplyr::pull(!!rlang::sym(by_group)) %>%
+        unique()
 
-    for (i in unique_by_group) {
-      data_scatter_automotive_company_i <- prep_scatter(
-        company_aggregated_alignment_bo_po,
-        company_aggregated_alignment_net,
-        year = year_scatter,
-        sector = sector_scatter,
-        region = region_scatter,
-        group_var = by_group,
-        groups_to_plot = i,
-        data_level = data_level_company
-      )
-
-      if (nrow(data_scatter_automotive_company_i) > 0) {
-        data_scatter_automotive_company_i %>%
-          readr::write_csv(
-            file = file.path(
-              output_analysis_aggregated_dir,
-              i,
-              glue::glue("data_scatter_automotive_company_by_{by_group}_{i}.csv")
-            ),
-            na = ""
-          )
-
-        plot_scatter(
-          data_scatter_automotive_company_i,
-          data_level = data_level_company,
+      for (i in unique_by_group) {
+        data_scatter_automotive_company_i <- prep_scatter(
+          company_aggregated_alignment_bo_po,
+          company_aggregated_alignment_net,
           year = year_scatter,
           sector = sector_scatter,
           region = region_scatter,
-          scenario_source = scenario_source_input,
-          scenario = scenario_select,
-          cap_outliers = 2,
-          floor_outliers = -2
+          group_var = by_group,
+          groups_to_plot = i,
+          data_level = data_level_company
         )
 
-        ggplot2::ggsave(
-          filename = glue::glue("plot_scatter_automotive_company_by_{by_group}_{i}.png"),
-          path = file.path(output_analysis_aggregated_dir, i),
-          width = 8,
-          height = 5
-        )
-      } else {
-        next()
+        if (nrow(data_scatter_automotive_company_i) > 0) {
+          data_scatter_automotive_company_i %>%
+            readr::write_csv(
+              file = file.path(
+                output_analysis_aggregated_dir,
+                i,
+                glue::glue("data_scatter_automotive_company_by_{by_group}_{i}.csv")
+              ),
+              na = ""
+            )
+
+          plot_scatter(
+            data_scatter_automotive_company_i,
+            data_level = data_level_company,
+            year = year_scatter,
+            sector = sector_scatter,
+            region = region_scatter,
+            scenario_source = scenario_source_input,
+            scenario = scenario_select,
+            cap_outliers = 2,
+            floor_outliers = -2
+          )
+
+          ggplot2::ggsave(
+            filename = glue::glue("plot_scatter_automotive_company_by_{by_group}_{i}.png"),
+            path = file.path(output_analysis_aggregated_dir, i),
+            width = 8,
+            height = 5
+          )
+        } else {
+          next()
+        }
       }
+    } else {
+      print(
+        glue::glue("Scatter plot BO/PO cannot be generated at company level, because of missing input files. Skipping!")
+      )
     }
   } else {
     print(
@@ -476,58 +522,64 @@ plot_aggregate_loanbooks <- function(config) {
   sector_scatter <- "power"
 
   if (length(by_group) == 1) {
-    unique_by_group <- company_aggregated_alignment_bo_po %>%
-      dplyr::filter(
-        .data[["sector"]] == .env[["sector_scatter"]],
-        !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
-      ) %>%
-      dplyr::pull(!!rlang::sym(by_group)) %>%
-      unique()
+    if (!is.null(company_aggregated_alignment_bo_po)) {
+      unique_by_group <- company_aggregated_alignment_bo_po %>%
+        dplyr::filter(
+          .data[["sector"]] == .env[["sector_scatter"]],
+          !grepl("benchmark_corporate_economy_", !!rlang::sym(by_group))
+        ) %>%
+        dplyr::pull(!!rlang::sym(by_group)) %>%
+        unique()
 
-    for (i in unique_by_group) {
-      data_scatter_power_company_i <- prep_scatter(
-        company_aggregated_alignment_bo_po,
-        company_aggregated_alignment_net,
-        year = year_scatter,
-        sector = sector_scatter,
-        region = region_scatter,
-        group_var = by_group,
-        groups_to_plot = i,
-        data_level = data_level_company
-      )
-
-      if (nrow(data_scatter_power_company_i) > 0) {
-        data_scatter_power_company_i %>%
-          readr::write_csv(
-            file = file.path(
-              output_analysis_aggregated_dir,
-              i,
-              glue::glue("data_scatter_power_company_by_{by_group}_{i}.csv")
-            ),
-            na = ""
-          )
-
-        plot_scatter(
-          data_scatter_power_company_i,
-          data_level = data_level_company,
+      for (i in unique_by_group) {
+        data_scatter_power_company_i <- prep_scatter(
+          company_aggregated_alignment_bo_po,
+          company_aggregated_alignment_net,
           year = year_scatter,
           sector = sector_scatter,
           region = region_scatter,
-          scenario_source = scenario_source_input,
-          scenario = scenario_select,
-          cap_outliers = 2,
-          floor_outliers = -2
+          group_var = by_group,
+          groups_to_plot = i,
+          data_level = data_level_company
         )
 
-        ggplot2::ggsave(
-          filename = glue::glue("plot_scatter_power_company_by_{by_group}_{i}.png"),
-          path = file.path(output_analysis_aggregated_dir, i),
-          width = 8,
-          height = 5
-        )
-      } else {
-        next()
+        if (nrow(data_scatter_power_company_i) > 0) {
+          data_scatter_power_company_i %>%
+            readr::write_csv(
+              file = file.path(
+                output_analysis_aggregated_dir,
+                i,
+                glue::glue("data_scatter_power_company_by_{by_group}_{i}.csv")
+              ),
+              na = ""
+            )
+
+          plot_scatter(
+            data_scatter_power_company_i,
+            data_level = data_level_company,
+            year = year_scatter,
+            sector = sector_scatter,
+            region = region_scatter,
+            scenario_source = scenario_source_input,
+            scenario = scenario_select,
+            cap_outliers = 2,
+            floor_outliers = -2
+          )
+
+          ggplot2::ggsave(
+            filename = glue::glue("plot_scatter_power_company_by_{by_group}_{i}.png"),
+            path = file.path(output_analysis_aggregated_dir, i),
+            width = 8,
+            height = 5
+          )
+        } else {
+          next()
+        }
       }
+    } else {
+      print(
+        glue::glue("Scatter plot BO/PO cannot be generated at company level, because of missing input files. Skipping!")
+      )
     }
   } else {
     print(

--- a/R/run_aggregate_alignment_metric.R
+++ b/R/run_aggregate_alignment_metric.R
@@ -188,6 +188,10 @@ run_aggregate_alignment_metric <- function(config) {
         " are present in the matched and prioritized loan book. Calculation of aggregated TMS results not possible. Skipping!"
       )
     )
+
+    company_technology_deviation_tms <- NULL
+    company_alignment_net_tms <- NULL
+    company_alignment_bo_po_tms <- NULL
   }
 
   ## prepare SDA company level P4B results for aggregation----
@@ -229,6 +233,8 @@ run_aggregate_alignment_metric <- function(config) {
         " are present in the matched and prioritized loan book. Calculation of aggregated SDA results not possible. Skipping!"
       )
     )
+
+    company_alignment_net_sda <- NULL
   }
 
 
@@ -264,37 +270,41 @@ run_aggregate_alignment_metric <- function(config) {
   }
 
   # net
-  if (nrow(company_alignment_net) > 0) {
-    aggregated_alignment_net <- company_alignment_net %>%
-      aggregate_alignment_loanbook_exposure(
-        matched = matched_prioritized,
+  if (!is.null(company_alignment_net)) {
+    if (nrow(company_alignment_net) > 0) {
+      aggregated_alignment_net <- company_alignment_net %>%
+        aggregate_alignment_loanbook_exposure(
+          matched = matched_prioritized,
+          level = "net",
+          .by = by_group
+        )
+
+      write_alignment_metric_to_csv(
+        data = aggregated_alignment_net,
+        output_dir = output_analysis_aggregated_dir,
         level = "net",
         .by = by_group
       )
-
-    write_alignment_metric_to_csv(
-      data = aggregated_alignment_net,
-      output_dir = output_analysis_aggregated_dir,
-      level = "net",
-      .by = by_group
-    )
+    }
   }
 
   # buildout / phaseout
-  if (nrow(company_alignment_bo_po_tms) > 0) {
-    aggregated_alignment_bo_po <- company_alignment_bo_po_tms %>%
-      aggregate_alignment_loanbook_exposure(
-        matched = matched_prioritized,
+  if (!is.null(company_alignment_bo_po_tms)) {
+    if (nrow(company_alignment_bo_po_tms) > 0) {
+      aggregated_alignment_bo_po <- company_alignment_bo_po_tms %>%
+        aggregate_alignment_loanbook_exposure(
+          matched = matched_prioritized,
+          level = "bo_po",
+          .by = by_group
+        )
+
+      write_alignment_metric_to_csv(
+        data = aggregated_alignment_bo_po,
+        output_dir = output_analysis_aggregated_dir,
         level = "bo_po",
         .by = by_group
       )
-
-    write_alignment_metric_to_csv(
-      data = aggregated_alignment_bo_po,
-      output_dir = output_analysis_aggregated_dir,
-      level = "bo_po",
-      .by = by_group
-    )
+    }
   }
 
 }


### PR DESCRIPTION
plotting of the net aggregate alignment metric requires results from the previous step to exist and not be NULL
These checks ensure the required results are available or skip the creation of the relevant plot

- returns `NULL` in `run_aggregate_alignment_metric()`, when no tms or sda result can be calculated, to allow the rest of the process to continue
- adds checks for existence of required input files for `plot_aggregate_alignment()`
- updates checks in `plot_aggregate_alignment()` to ensure inputs are not `NULL` and have some usable content
- wherever an input is missing for a result that does not hinder the remainder of the function to produce useful outputs, the relevant section is skipped
- some old checks in `plot_aggregate_alignment()` are simplified and some obsolete conditions are removed