### PR TITLE
require r2dii.match >= 0.2.0 for `join_id` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Imports:
     networkD3,
     r2dii.analysis,
     r2dii.data (>= 0.5.0),
-    r2dii.match,
+    r2dii.match (>= 0.2.0),
     r2dii.plot (>= 0.4.0),
     readr (>= 2.0.0),
     readxl,


### PR DESCRIPTION
https://github.com/RMI-PACTA/r2dii.match/blob/main/NEWS.md#r2diimatch-020