### PR TITLE
process `msg` in `caller_env`

### DIFF
--- a/R/ask_for_permission.R
+++ b/R/ask_for_permission.R
@@ -1,5 +1,5 @@
 ask_for_permission <- function(msg) {
-  if (!yesno::yesno(cli::cli_text(msg))) {
+  if (!yesno::yesno(cli::cli_text(msg, .envir = rlang::caller_env()))) {
     cli::cli_abort(
       message = "The process cannot continue because you answered \"no\"",
       call = rlang::caller_env()


### PR DESCRIPTION
- closes #221 

sometimes (weirdly) an error was happening because the `msg` text was processing in the `ask_for_permission()` environment and was not finding variables used in it.

I'm guessing that with `.envir = parent.frame()` (the default in `cli::cli_text()`), it's looking in *the parent of the `prepare_abcd()` function* not the `ask_for_permission()` function, and therefore not finding the `output_prepare_dir` variable 🤷🏻?