### PR TITLE
add different install instructions for release and dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/RMI-PACTA/pacta.multi.loanbook/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/pacta.multi.loanbook/actions/workflows/R-CMD-check.yaml)
 [![CRAN
-status](https://www.r-pkg.org/badges/version/pacta.multi.loanbook)](https://CRAN.R-project.org/package=pacta.multi.loanbook)
+status](https://www.r-pkg.org/badges/version/pacta.multi.loanbook)](https://CRAN.R-project.org/package=pacta.multi.loanbook){.pkgdown-release}
 [![pacta.multi.loanbook status badge](https://rmi-pacta.r-universe.dev/badges/pacta.multi.loanbook)](https://rmi-pacta.r-universe.dev/pacta.multi.loanbook)
 <!-- badges: end -->
 
@@ -14,16 +14,19 @@ The `pacta.multi.loanbook` package offers a standardized, user-friendly way to c
 Designed for financial supervisory contexts, it simplifies climate alignment analysis across many lending institutions. The package streamlines steps to prevent repetition while allowing flexibility to tailor the analysis for specific project needs, providing valuable insights into transition alignment and risk.
 
 ## Installation
-Install the development version of the package from GitHub with:
+
+<!--
+You can install the release version of the package by running the following command in R:
 
 ``` r
-# install.packages("pak")
-pak::pak("RMI-PACTA/pacta.multi.loanbook")
+install.packages("pacta.multi.loanbook")
 ```
+-->
 
-Verify the installation with: 
+You can install the development version of the package from GitHub with:
+
 ``` r
-library(pacta.multi.loanbook)
+pak::pak("RMI-PACTA/pacta.multi.loanbook")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 <!-- badges: start -->
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![R-CMD-check](https://github.com/RMI-PACTA/pacta.multi.loanbook/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/RMI-PACTA/pacta.multi.loanbook/actions/workflows/R-CMD-check.yaml)
-[![CRAN
-status](https://www.r-pkg.org/badges/version/pacta.multi.loanbook)](https://CRAN.R-project.org/package=pacta.multi.loanbook){.pkgdown-release}
+<!-- [![CRAN
+status](https://www.r-pkg.org/badges/version/pacta.multi.loanbook)](https://CRAN.R-project.org/package=pacta.multi.loanbook) -->
 [![pacta.multi.loanbook status badge](https://rmi-pacta.r-universe.dev/badges/pacta.multi.loanbook)](https://rmi-pacta.r-universe.dev/pacta.multi.loanbook)
 <!-- badges: end -->
 

--- a/vignettes/cookbook.Rmd
+++ b/vignettes/cookbook.Rmd
@@ -207,17 +207,29 @@ RStudio is an integrated development environment (IDE) for R developed by Posit.
 
 ### `pacta.multi.loanbook` R package
 
-The `pacta.multi.loanbook` package is the main software tool that you will use to run the PACTA for Supervisors analysis. You can install the package from the [RStudio CRAN mirror](https://cran.r-project.org/web/packages/pacta.multi.loanbook/index.html) by running the following command in R:
+The `pacta.multi.loanbook` package is the main software tool that you will use to run the PACTA for Supervisors analysis.
 
-```{r install_package, eval = FALSE}
+::: {.pkgdown-release}
+You can install the package from the [RStudio CRAN mirror](https://cran.r-project.org/web/packages/pacta.multi.loanbook/index.html) by running the following command in R:
+
+``` r
 install.packages("pacta.multi.loanbook")
 ```
 
-Alternatively, you can install the development version of the package from GitHub by running the following command in R:
+You can install the development version of pkgdown from GitHub with:
 
-```{r install_dev_package, eval = FALSE}
-pak::pak("RMI-PACTA/pacta.multi.loanbook")
+``` r
+pak::pak("r-lib/pkgdown")
 ```
+:::
+
+::: {.pkgdown-devel}
+You can install the development version of pkgdown from GitHub with:
+
+``` r
+pak::pak("r-lib/pkgdown")
+```
+:::
 
 ### Required R packages
 


### PR DESCRIPTION
- closes #217 
- sets us up to do #210 very easily once it's released on CRAN (by simply removing the comment fences)

note: also removes the text saying which repo `install.packages()` installs from, which technically can not be know since it's dependent on the user's setup

note: also removes the text about verifying the install with `library(pacta.multi.loanbook)` because I don't think that makes much sense nor is it really a great way to actually verify install