### PR TITLE
remove TODO about moving `plot_match_success_rate()` into `r2dii.plot`

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -1,4 +1,3 @@
-# TODO: move to `r2dii.plot` and export
 plot_match_success_rate <- function(data,
                                     metric_type = c("absolute", "relative"),
                                     match_success_type = c("n", "outstanding", "credit_limit"),


### PR DESCRIPTION
- closes #236 

now tracked in https://github.com/RMI-PACTA/r2dii.plot/issues/574