### PR TITLE
Pick up cans down the road

### DIFF
--- a/R/match_loanbooks.R
+++ b/R/match_loanbooks.R
@@ -79,10 +79,16 @@ match_loanbooks <- function(config) {
     assert_inherits(matching_p, "numeric")
   }
 
-  # TODO: check for data.frame
-  # assert_length(matching_overwrite, 1L)
-  # assert_inherits(matching_overwrite, "numeric")
-  #
+  if (!is.null(matching_overwrite)) {
+    assert_inherits(matching_overwrite, "data.frame")
+    # cols are based on r2dii.data::overwrite_demo
+    assert_expected_columns(
+      data = matching_overwrite,
+      cols = c("level", "id_2dii", "name", "sector", "source"),
+      desc = "matching_overwrite"
+    )
+  }
+
   # TODO: check for join_object
   # assert_length(matching_join_id, 1L)
   # assert_inherits(matching_join_id, "numeric")

--- a/R/match_loanbooks.R
+++ b/R/match_loanbooks.R
@@ -156,7 +156,6 @@ match_loanbooks <- function(config) {
             p = matching_p,
             overwrite = matching_overwrite,
             join_id = matching_join_id
-            # TODO: allow surfacing the other match_name args
           )
         }
       )

--- a/R/match_loanbooks.R
+++ b/R/match_loanbooks.R
@@ -41,7 +41,8 @@ match_loanbooks <- function(config) {
   matching_by_sector <- get_match_by_sector(config)
   matching_min_score <- get_match_min_score(config)
   matching_method <- get_match_method(config)
-  matching_p <- get_match_p(config)
+  # argument p only applies for Jaro-Winkler method
+  if (matching_method == "jw") {matching_p <- get_match_p(config)}
   matching_overwrite <- get_match_overwrite(config)
   matching_join_id <- get_match_join_id(config)
 
@@ -73,8 +74,10 @@ match_loanbooks <- function(config) {
   assert_length(matching_method, 1L)
   assert_inherits(matching_method, "character")
 
-  assert_length(matching_p, 1L)
-  assert_inherits(matching_p, "numeric")
+  if (matching_method == "jw") {
+    assert_length(matching_p, 1L)
+    assert_inherits(matching_p, "numeric")
+  }
 
   # TODO: check for data.frame
   # assert_length(matching_overwrite, 1L)

--- a/R/match_loanbooks.R
+++ b/R/match_loanbooks.R
@@ -89,9 +89,9 @@ match_loanbooks <- function(config) {
     )
   }
 
-  # TODO: check for join_object
-  # assert_length(matching_join_id, 1L)
-  # assert_inherits(matching_join_id, "numeric")
+  if (!is.null(matching_join_id)) {
+    assert_inherits(matching_join_id, "character")
+  }
 
   assert_length(matching_use_manual_sector_classification, 1L)
   assert_inherits(matching_use_manual_sector_classification, "logical")

--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -146,7 +146,6 @@ plot_aggregate_loanbooks <- function(config) {
 
   # generate plots for system-wide analysis----
   ### sankey plot----
-  # TODO: when benchmarks get re-introduced, they need to be removed here
   # Plot sankey plot of financial flows scenario alignment - examples
   if (!is.null(company_aggregated_alignment_net)) {
     data_sankey_sector <- prep_sankey(

--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -388,8 +388,6 @@ plot_aggregate_loanbooks <- function(config) {
 
   # group level plots ----
   # create sub directories for each relevant group.
-  # TODO: Note that this implies that no groups across different .by variables
-  # should have the same values, as this will confuse output directories
 
   if (
     length(by_group) == 1 &

--- a/R/plot_aggregate_loanbooks.R
+++ b/R/plot_aggregate_loanbooks.R
@@ -27,6 +27,23 @@ plot_aggregate_loanbooks <- function(config) {
   by_group <- get_by_group(config)
   by_group <- check_and_prepare_by_group(by_group)
 
+  # validate config values ----
+
+  assert_length(scenario_source_input, 1L)
+  assert_inherits(scenario_source_input, "character")
+
+  assert_length(scenario_select, 1L)
+  assert_inherits(scenario_select, "character")
+
+  assert_length(region_select, 1L)
+  assert_inherits(region_select, "character")
+
+  assert_length(start_year, 1L)
+  assert_inherits(start_year, "integer")
+
+  assert_length(time_frame_select, 1L)
+  assert_inherits(time_frame_select, "integer")
+
   # load required data----
 
   if (is.null(by_group)) {

--- a/R/run_aggregate_alignment_metric.R
+++ b/R/run_aggregate_alignment_metric.R
@@ -93,7 +93,6 @@ run_aggregate_alignment_metric <- function(config) {
     dplyr::select(-"increasing_or_decreasing")
 
   # remove non standard columns from matched_prioritzed when calling r2dii.analysis
-  # TODO: check if this needs to be adjusted to remove other by_group columns
   matched_prio_non_standard_cols <- names(matched_prioritized)[!names(matched_prioritized) %in% col_standard_matched_prioritized]
 
   # only calculate net aggregated aligment results if the selected scenario has a trajectory for at least one sector in the matched_prioritzed loan book

--- a/R/run_aggregate_alignment_metric.R
+++ b/R/run_aggregate_alignment_metric.R
@@ -20,6 +20,36 @@ run_aggregate_alignment_metric <- function(config) {
   by_group <- get_by_group(config)
   by_group <- check_and_prepare_by_group(by_group)
 
+  # validate config values ----
+
+  assert_length(dir_prepared_abcd, 1L)
+  assert_inherits(dir_prepared_abcd, "character")
+  assert_dir_exists(dir_prepared_abcd, desc = "Output - prepare ABCD")
+  assert_file_exists(file.path(dir_prepared_abcd, "abcd_final.csv"), desc = "ABCD final")
+
+  assert_length(path_scenario_tms, 1L)
+  assert_inherits(path_scenario_tms, "character")
+  assert_file_exists(path_scenario_tms, desc = "Input - Scenario: target market share (TMS)")
+
+  assert_length(path_scenario_sda, 1L)
+  assert_inherits(path_scenario_sda, "character")
+  assert_file_exists(path_scenario_sda, desc = "Input - Scenario: sectoral decarbonization approach (SDA)")
+
+  assert_length(scenario_source_input, 1L)
+  assert_inherits(scenario_source_input, "character")
+
+  assert_length(scenario_select, 1L)
+  assert_inherits(scenario_select, "character")
+
+  assert_length(region_select, 1L)
+  assert_inherits(region_select, "character")
+
+  assert_length(start_year, 1L)
+  assert_inherits(start_year, "integer")
+
+  assert_length(time_frame, 1L)
+  assert_inherits(time_frame, "integer")
+
   # load input data----
   region_isos_select <- r2dii.data::region_isos %>%
     dplyr::filter(

--- a/R/run_calculate_loanbook_coverage.R
+++ b/R/run_calculate_loanbook_coverage.R
@@ -47,7 +47,6 @@ run_calculate_loanbook_coverage <- function(config) {
   )
 
   # add helper column to facilitate calculation of meta results----
-  # TODO: decide if this should be removed from outputs
   if (is.null(by_group)) {
     by_group <- "meta"
     matched_prioritized <- dplyr::mutate(.data = matched_prioritized, meta = "meta")

--- a/R/run_calculate_match_success_rate.R
+++ b/R/run_calculate_match_success_rate.R
@@ -90,7 +90,6 @@ run_calculate_match_success_rate <- function(config) {
   )
 
   # add helper column to facilitate calculation of meta results----
-  # TODO: decide if this should be removed from outputs
   if (is.null(by_group)) {
     by_group <- "meta"
     raw_lbk <- raw_lbk %>%

--- a/R/run_pacta.R
+++ b/R/run_pacta.R
@@ -101,7 +101,6 @@ run_pacta <- function(config) {
   )
 
   # add helper column to facilitate calculation of meta results----
-  # TODO: decide if this should be removed from outputs
   if (is.null(by_group)) {
     by_group <- "meta"
     matched_prioritized <- matched_prioritized %>%

--- a/R/run_pacta.R
+++ b/R/run_pacta.R
@@ -35,7 +35,35 @@ run_pacta <- function(config) {
   by_group <- check_and_prepare_by_group(by_group)
   by_group_ext <- if (is.null(by_group)) { "_meta" } else { paste0("_", by_group) }
 
-  # TODO: add check if all files exist, resort to test files if not
+  # validate config values ----
+
+  assert_length(dir_prepared_abcd, 1L)
+  assert_inherits(dir_prepared_abcd, "character")
+  assert_dir_exists(dir_prepared_abcd, desc = "Output - prepare ABCD")
+  assert_file_exists(file.path(dir_prepared_abcd, "abcd_final.csv"), desc = "ABCD final")
+
+  assert_length(path_scenario_tms, 1L)
+  assert_inherits(path_scenario_tms, "character")
+  assert_file_exists(path_scenario_tms, desc = "Input - Scenario: target market share (TMS)")
+
+  assert_length(path_scenario_sda, 1L)
+  assert_inherits(path_scenario_sda, "character")
+  assert_file_exists(path_scenario_sda, desc = "Input - Scenario: sectoral decarbonization approach (SDA)")
+
+  assert_length(scenario_source_input, 1L)
+  assert_inherits(scenario_source_input, "character")
+
+  assert_length(scenario_select, 1L)
+  assert_inherits(scenario_select, "character")
+
+  assert_length(region_select, 1L)
+  assert_inherits(region_select, "character")
+
+  assert_length(start_year, 1L)
+  assert_inherits(start_year, "integer")
+
+  assert_length(time_frame_select, 1L)
+  assert_inherits(time_frame_select, "integer")
 
   # load input data----
   region_isos_select <- r2dii.data::region_isos %>%

--- a/data-raw/data_dictionary.R
+++ b/data-raw/data_dictionary.R
@@ -143,7 +143,6 @@ dd_data_scatter_alignment_exposure <- dplyr::tribble(
   "data_scatter_alignment_exposure", "sum_loan_size_outstanding", "double", "Sum of outstanding loan size at the banking book-by-sector level of all loans analysed within this (group of) banking book(s)", "Numerical value greater or equal to 0"
 )
 
-# TODO: currently the sector is only indicated by the file name, not by a column in the data
 dd_data_scatter_sector <- dplyr::tribble(
   ~dataset, ~column, ~typeof, ~definition, ~value,
   "data_scatter_sector", "name", "character", "Name of the entity to analyse. If analysed at group level, this variable contains the values of <by_group>. If analysed at company level, it contains the values of 'name_abcd'", "An identifying name of the entity",

--- a/data-raw/data_dictionary.R
+++ b/data-raw/data_dictionary.R
@@ -225,7 +225,6 @@ dd_data_emission_intensity <- dplyr::tribble(
   "data_emission_intensity", "label", "character", "Same as 'emission_factor_metric', formatted for display in plot", "Must be one of the following: 'projected', 'corporate_economy', or 'target_<scenario>', but formatted for display"
 )
 
-# TODO: possibly deprecate this output
 dd_companies_included <- dplyr::tribble(
   ~dataset, ~column, ~typeof, ~definition, ~value,
   "companies_included", "<by_group>", "character", "Any additional descriptor either at the loan level or at the banking book level. This is used to calculate grouped results by additional dimensions of interest, such as types of FIs or types of loans", "Any variable name is permissible, that is not already used otherwise. All entries in the banking book should have a corresponding value. NULL is permissible and implies no grouping",

--- a/data-raw/data_dictionary.R
+++ b/data-raw/data_dictionary.R
@@ -250,7 +250,6 @@ dd_summary_statistics_loanbook_coverage <- dplyr::tribble(
   "summary_statistics_loanbook_coverage", "share_production_financed", "double", "Share of production of companies identified for analysis relative to production by all companies in the reference dataset. This is a proxy for how much of the output of a region is covered by the analysis", "Numerical value between 0 and 1"
 )
 
-# TODO: probably better to export data_lbk_match_success_rate, which is actual format used in plots
 dd_lbk_match_success_rate <- dplyr::tribble(
   ~dataset, ~column, ~typeof, ~definition, ~value,
   "lbk_match_success_rate", "<by_group>", "character", "Any additional descriptor either at the loan level or at the banking book level. This is used to calculate grouped results by additional dimensions of interest, such as types of FIs or types of loans", "Any variable name is permissible, that is not already used otherwise. All entries in the banking book should have a corresponding value. NULL is permissible and implies no grouping",


### PR DESCRIPTION
relates to #213 

- removes obsolete TODOs
  - `# TODO: allow surfacing the other match_name args` --> no plans to do so
  - `# TODO: when benchmarks get re-introduced, they need to be removed here` --> no plans to reintroduce benchmarks for net alignment metric. In case we want to do so in the future, we should reconsider the implementation more broadly
  - `# TODO: Note that this implies that no groups across different .by variables
  should have the same values, as this will confuse output directories` --> this was effectively handled by https://github.com/RMI-PACTA/pacta.multi.loanbook/pull/179, because every additional run with a new by_group variable is either going to be written to a new directory (hence there will be no confusion of equally named sub-directories), or it will replace the previous output directory entirely (hence again no naming conflicts for equally named sub groups created in different runs)
  - `# TODO: check if this needs to be adjusted to remove other by_group columns` the extended implementation of `by_group` (#108, #120, #127) has not lead to any issues with generating outputs
  - `# TODO: decide if this should be removed from outputs` --> no pressing need to remove a column that indicates the calculation was run at meta level
- relevant TODOs have received their own GH issues (#248, #249, #250)
- close TODOs related to config validations by adding the relevant assertions

Note

TODOs related to the plots, tests, and examples in the user-facing functions will be handled in another PR