### PR TITLE
docs: remove explicit cookbook section numbering

### DIFF
--- a/vignettes/cookbook_advanced_use_cases.Rmd
+++ b/vignettes/cookbook_advanced_use_cases.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Cookbook - (5) Advanced Use Cases"
+title: "Advanced Use Cases"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Cookbook - (5) Advanced Use Cases}
+  %\VignetteIndexEntry{Advanced Use Cases}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/cookbook_advanced_use_cases.Rmd
+++ b/vignettes/cookbook_advanced_use_cases.Rmd
@@ -194,4 +194,4 @@ We can now check if:
 - One way to circumvent this slighlty cumbersome process would be to create a combined variable in the loan books, that includes information on both the bank and the net zero pledge. This would allow getting the required information in one run.
 - Any bank that we identify that has made a net zero pledge but is strongly misaligned may be at risk of losing reputation and/or being sued over noncompliance with its pledge. Of course, misalignment is rarely ever a sufficient criterion to judge if reputational damage or legal risk is likely to materialize. Other factors, such as progress made in past efforts, implementation of transition plans, lending strategy with regard to transition finance, etc. should be considered too. But strong misalignment should be considered a warning signal, that warrants further investigation into these other aspects and possibly a dialogue with the affected bank.
 
-**PREVIOUS CHAPTER:** [4 - Interpretation of Results](cookbook_interpretation.html)
+**PREVIOUS CHAPTER:** [Interpretation of Results](cookbook_interpretation.html)

--- a/vignettes/cookbook_interpretation.Rmd
+++ b/vignettes/cookbook_interpretation.Rmd
@@ -431,6 +431,6 @@ The variables in the table map to the figures as follows:
 - `net`: The net aggregate alignment metric of the loan book or company. Maps to the hue of the dot. Aligned loan books or companies have a positive value (green hue), misaligned ones have a negative value (red hue).
 - `datapoint`: Indicates if the results are calculated at loan book or company level.
 
-**PREVIOUS CHAPTER:** [3 - Running the Analysis](cookbook_running_the_analysis.html)
+**PREVIOUS CHAPTER:** [Running the Analysis](cookbook_running_the_analysis.html)
 
-**NEXT CHAPTER:** [5 - Advanced Use Cases](cookbook_advanced_use_cases.html)
+**NEXT CHAPTER:** [Advanced Use Cases](cookbook_advanced_use_cases.html)

--- a/vignettes/cookbook_interpretation.Rmd
+++ b/vignettes/cookbook_interpretation.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Cookbook - (4) Interpretation of Results"
+title: "Interpretation of Results"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Cookbook - (4) Interpretation of Results}
+  %\VignetteIndexEntry{Interpretation of Results}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/cookbook_overview.Rmd
+++ b/vignettes/cookbook_overview.Rmd
@@ -49,6 +49,14 @@ plot_table <- function(table) {
 
 This cookbook provides a step-by-step guide to running the PACTA for Supervisors analysis using the `pacta.multi.loanbook` package. The analysis is designed to help financial supervisors assess the alignment of banks' loan books with the Paris Agreement goals.
 
+The sections of the cookbook are as follows:
+
+1. **Overview**: This section provides an overview of the PACTA for Supervisors analysis and its main steps.
+2. **Preparatory Steps**: Prepare the ABCD data and optionally a custom sector split.
+3. **Running the Analysis**: Match the raw loan books to the ABCD data and run the PACTA for Supervisors analysis.
+4. **Interpretation of Results**: Interpret the results of the analysis and understand the outputs.
+5. **Advanced Topics**: Learn about advanced topics such as custom grouping of results and how to adjust the analysis parameters for best results on advanced research questions.
+
 ## What is the PACTA for Supervisors analysis?
 
 PACTA for Supervisors is based on the PACTA methodology, which assesses the alignment of financial portfolios with climate goals utilizing forward-looking asset-based company data (ABCD) that is linked to financial assets and compares the production profiles of those companies with technology and emissions pathways from climate transition scenarios at the sector and/or technology level.

--- a/vignettes/cookbook_overview.Rmd
+++ b/vignettes/cookbook_overview.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Cookbook - (1) Overview"
+title: "Overview"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Cookbook - (1) Overview}
+  %\VignetteIndexEntry{Overview}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/cookbook_overview.Rmd
+++ b/vignettes/cookbook_overview.Rmd
@@ -52,10 +52,10 @@ This cookbook provides a step-by-step guide to running the PACTA for Supervisors
 The sections of the cookbook are as follows:
 
 1. **Overview**: This section provides an overview of the PACTA for Supervisors analysis and its main steps.
-2. **Preparatory Steps**: Prepare the ABCD data and optionally a custom sector split.
-3. **Running the Analysis**: Match the raw loan books to the ABCD data and run the PACTA for Supervisors analysis.
-4. **Interpretation of Results**: Interpret the results of the analysis and understand the outputs.
-5. **Advanced Topics**: Learn about advanced topics such as custom grouping of results and how to adjust the analysis parameters for best results on advanced research questions.
+2. **[Preparatory Steps](cookbook_preparatory_steps.html)**: Prepare the ABCD data and optionally a custom sector split.
+3. **[Running the Analysis](cookbook_running_the_analysis.html)**: Match the raw loan books to the ABCD data and run the PACTA for Supervisors analysis.
+4. **[Interpretation of Results](cookbook_interpretation.html)**: Interpret the results of the analysis and understand the outputs.
+5. **[Advanced Topics](cookbook_advanced_use_cases.html)**: Learn about advanced topics such as custom grouping of results and how to adjust the analysis parameters for best results on advanced research questions.
 
 ## What is the PACTA for Supervisors analysis?
 

--- a/vignettes/cookbook_overview.Rmd
+++ b/vignettes/cookbook_overview.Rmd
@@ -78,4 +78,4 @@ The main steps of the analysis are as follows:
 
 This cookbook will guide you through each of the steps of the analysis in detail, explain the required input data sets and software, and provide guidance on how to interpret the results.
 
-**NEXT CHAPTER:** [2 - Preparatory Steps](cookbook_preparatory_steps.html)
+**NEXT CHAPTER:** [Preparatory Steps](cookbook_preparatory_steps.html)

--- a/vignettes/cookbook_preparatory_steps.Rmd
+++ b/vignettes/cookbook_preparatory_steps.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Cookbook - (2) Preparatory Steps"
+title: "Preparatory Steps"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Cookbook - (2) Preparatory Steps}
+  %\VignetteIndexEntry{Preparatory Steps}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/cookbook_preparatory_steps.Rmd
+++ b/vignettes/cookbook_preparatory_steps.Rmd
@@ -286,6 +286,6 @@ Before running the PACTA for Supervisors analysis, you should make sure that you
   - [ ] Created appropriate values for all input and ouput directories in the `config.yml` file
 
 
-**PREVIOUS CHAPTER:** [1 - Overview](cookbook_overview.html)
+**PREVIOUS CHAPTER:** [Overview](cookbook_overview.html)
 
-**NEXT CHAPTER:** [3 - Running the Analysis](cookbook_running_the_analysis.html)
+**NEXT CHAPTER:** [Running the Analysis](cookbook_running_the_analysis.html)

--- a/vignettes/cookbook_running_the_analysis.Rmd
+++ b/vignettes/cookbook_running_the_analysis.Rmd
@@ -182,6 +182,6 @@ All these options are documented in more detail the [section on project paramete
 
 Usually, it will be interesting to run the analysis for more than one by_group, possibly also for multiple combinations of the other parameters. You will therefore have to run the analysis as many times as there are combinations of interest that you wish to generate results for.
 
-**PREVIOUS CHAPTER:** [2 - Preparatory Steps](cookbook_preparatory_steps.html)
+**PREVIOUS CHAPTER:** [Preparatory Steps](cookbook_preparatory_steps.html)
 
-**NEXT CHAPTER:** [4 - Interpretation of Results](cookbook_interpretation.html)
+**NEXT CHAPTER:** [Interpretation of Results](cookbook_interpretation.html)

--- a/vignettes/cookbook_running_the_analysis.Rmd
+++ b/vignettes/cookbook_running_the_analysis.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Cookbook - (3) Running the Analysis"
+title: "Running the Analysis"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Cookbook - (3) Running the Analysis}
+  %\VignetteIndexEntry{Running the Analysis}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
The order is defined implicitly by the order in which it appears on the `pkgdown.yml`:
https://github.com/RMI-PACTA/pacta.multi.loanbook/blob/3f08f0ded38803dd34937155eb16cfece32e4a30/_pkgdown.yml#L41-L46

Explicit numbering of the sections is superfluous and clunky. 
![Screenshot 2024-11-22 at 13 02 13](https://github.com/user-attachments/assets/43c76e9b-f962-4e85-a261-95273842f704)