### PR TITLE
fix grammar in `match_loanbooks()` documentation

### DIFF
--- a/R/match_loanbooks.R
+++ b/R/match_loanbooks.R
@@ -1,15 +1,16 @@
 #' Match raw input loan books with ABCD for PACTA for Supervisors analysis
 #'
 #' @description
-#' `match_loanbooks()` runs the necessary steps to match the raw input loan books with the
-#' asset based company data (ABCD) used in the PACTA for Supervisors analysis.
-#' Specifically, it prepares matched loan books based on name matching or direct
-#' identifiers, depending on the configuration. The output matched loan books
-#' need to be manually validated for further processing.
-#' Parameters the matching step are read from a `config.yml` file and follow the
-#' options available in `r2dii.match::match_name`. The function is called for its
-#' side effects and writes the prepared data sets to the directory `output/match`,
-#' where `output` is the output directory specified in the `config.yml`.
+#' `match_loanbooks()` runs the necessary steps to match the raw input loan
+#' books with the asset based company data (ABCD) used in the PACTA for
+#' Supervisors analysis. Specifically, it prepares matched loan books based on
+#' name matching or direct identifiers, depending on the configuration. The
+#' output matched loan books need to be manually validated for further
+#' processing. Parameters for the matching step are read from a `config.yml`
+#' file and follow the options available in `r2dii.match::match_name`. The
+#' function is called for its side effects and writes the prepared data sets to
+#' the directory `output/match`, where `output` is the output directory
+#' specified in the `config.yml`.
 #'
 #' @param config either a path to a config.yml file or a list of parameters
 #'

--- a/man/match_loanbooks.Rd
+++ b/man/match_loanbooks.Rd
@@ -10,13 +10,14 @@ match_loanbooks(config)
 \item{config}{either a path to a config.yml file or a list of parameters}
 }
 \description{
-\code{match_loanbooks()} runs the necessary steps to match the raw input loan books with the
-asset based company data (ABCD) used in the PACTA for Supervisors analysis.
-Specifically, it prepares matched loan books based on name matching or direct
-identifiers, depending on the configuration. The output matched loan books
-need to be manually validated for further processing.
-Parameters the matching step are read from a \code{config.yml} file and follow the
-options available in \code{r2dii.match::match_name}. The function is called for its
-side effects and writes the prepared data sets to the directory \code{output/match},
-where \code{output} is the output directory specified in the \code{config.yml}.
+\code{match_loanbooks()} runs the necessary steps to match the raw input loan
+books with the asset based company data (ABCD) used in the PACTA for
+Supervisors analysis. Specifically, it prepares matched loan books based on
+name matching or direct identifiers, depending on the configuration. The
+output matched loan books need to be manually validated for further
+processing. Parameters for the matching step are read from a \code{config.yml}
+file and follow the options available in \code{r2dii.match::match_name}. The
+function is called for its side effects and writes the prepared data sets to
+the directory \code{output/match}, where \code{output} is the output directory
+specified in the \code{config.yml}.
 }


### PR DESCRIPTION
- closes #278 