### PR TITLE
clearer description of start_year and scenario dependency

### DIFF
--- a/vignettes/cookbook_preparatory_steps.Rmd
+++ b/vignettes/cookbook_preparatory_steps.Rmd
@@ -68,7 +68,7 @@ While the raw input values of the scenarios are based on models from external th
 - [pacta.scenario.data.preparation](https://github.com/RMI-PACTA/pacta.scenario.data.preparation)
 - [workflow.scenario.preparation](https://github.com/RMI-PACTA/workflow.scenario.preparation)
 
-Since RMI has taken over stewardship of PACTA, the prepared scenario files can also be accessed as CSV downloads on the [PACTA website](https://pacta.rmi.org/pacta-for-banks-2020/) under the "Methodology and Documents" tab of the "PACTA for Banks" section. The files are usually updated annually based on the latest scenario publications.
+Since RMI has taken over stewardship of PACTA, the prepared scenario files can also be accessed as CSV downloads on the [PACTA website](https://pacta.rmi.org/pacta-for-banks-2020/) under the "Methodology and Documents" tab of the "PACTA for Banks" section. The files are usually updated annually based on the latest scenario publications and as a general rule, the year of the publication defines the initial year of the scenario data set. This is commonly also used as the start year of the analysis, which is specified in the `config.yml` file.
 
 ### Raw Loan Books
 


### PR DESCRIPTION
closes #308 

- `cookbook_preparatory_steps.Rmd` gains clearer description of how the year of the scenario publication and the `start_year` are connected

also see comment in the underlying GH issue