### PR TITLE
pkgdown: Reorder sections of `_pkgdown.yml`

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -21,20 +21,6 @@ reference:
   - has_keyword("datasets")
 
 articles:
-- title: Methodology
-  navbar: Methodology
-  contents:
-  - company_alignment_metric
-  - loanbook_aggregated_alignment_metric
-  - sector_split
-
-- title: Documentation
-  desc: Documentation of files and objects used for input and output
-  navbar: Documentation
-  contents:
-  - config_yml
-  - data_dictionary
-
 - title: Cookbook
   desc: Cookbook demonstrating how to use this package for your own projects
   navbar: Cookbook
@@ -44,6 +30,20 @@ articles:
   - cookbook_running_the_analysis
   - cookbook_interpretation
   - cookbook_advanced_use_cases
+
+- title: Documentation
+  desc: Documentation of files and objects used for input and output
+  navbar: Documentation
+  contents:
+  - config_yml
+  - data_dictionary
+
+- title: Methodology
+  navbar: Methodology
+  contents:
+  - company_alignment_metric
+  - loanbook_aggregated_alignment_metric
+  - sector_split
 
 navbar:
   structure:


### PR DESCRIPTION
It feels like the "Cookbook" should be first? Unless there is a reason not to do so...