### PR TITLE
use a safer method of extracting the filename from a path

### DIFF
--- a/R/run_calculate_match_success_rate.R
+++ b/R/run_calculate_match_success_rate.R
@@ -75,8 +75,8 @@ run_calculate_match_success_rate <- function(config) {
 
   raw_lbk <- raw_lbk %>%
     dplyr::mutate(
-      group_id = gsub(glue::glue("{dir_loanbooks}/"), "", .data[["group_id"]]),
-      group_id = gsub(".csv", "", .data[["group_id"]])
+      group_id = basename(.data[["group_id"]]),
+      group_id = sub("[.]csv$", "", .data[["group_id"]])
     )
 
   ## load matched prioritized loan books----


### PR DESCRIPTION
- related to #349 
- related to #352 

fixes [bug discovered](https://win-builder.r-project.org/wojaD4y2X6ol/00check.log) with `devtools::check_win_devel()`
> ── Failure ('test-3-prioritise_and_diagnose.R:45:3'): with known input, runs without error ──
  Expected `suppressWarnings(prioritise_and_diagnose(config))` to run without any errors.
  i Actually got a <dplyr:::mutate_error> with text:
    i In argument: `group_id = gsub(glue::glue("{dir_loanbooks}/"), "", .data[["group_id"]])`.
    Caused by error in `gsub()`:
    ! invalid regular expression 'D:\temp\2024_12_12_20_04_01_7854\Rtmpwtw7BJ/test-data/input/loanbooks/', reason 'Invalid back reference'
 