### PR TITLE
set `_R_CHECK_CRAN_INCOMING_` to `TRUE` in CI for more robust testing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,3 +64,5 @@ jobs:
           _R_CHECK_CRAN_INCOMING_: true
           _R_CHECK_CRAN_INCOMING_REMOTE_: true
           _R_CHECK_CRAN_INCOMING_USE_ASPELL_: true
+          _R_CHECK_URLS_SHOW_301_STATUS_: true
+          _R_CHECK_RD_LINE_WIDTHS_: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -60,3 +60,5 @@ jobs:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
           error-on: '"note"'
+        env:
+          _R_CHECK_CRAN_INCOMING_: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -62,3 +62,5 @@ jobs:
           error-on: '"note"'
         env:
           _R_CHECK_CRAN_INCOMING_: true
+          _R_CHECK_CRAN_INCOMING_REMOTE_: true
+          _R_CHECK_CRAN_INCOMING_USE_ASPELL_: true


### PR DESCRIPTION
should see similar errors discovered with `devtools::check_win_devel()`