### PR TITLE
don't exclude `dev/` when building pkgdown site

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -49,4 +49,3 @@ jobs:
           force: false
           clean-exclude: |
             pr-preview/
-            dev/

--- a/.github/workflows/pr-preview-pkgdown.yml
+++ b/.github/workflows/pr-preview-pkgdown.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: docs
+          source-dir: docs/dev
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           action: auto


### PR DESCRIPTION
- closes #372 (hopefully)