### PR TITLE
do not `clean` when building pkgdown site

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -45,7 +45,5 @@ jobs:
         with:
           branch: gh-pages
           folder: docs
-          clean: true
+          clean: false
           force: false
-          clean-exclude: |
-            pr-preview/


### PR DESCRIPTION
This is the only reliable way I see to stop the pkgdown action from wiping the existing release site when building a dev site. The disadvantage is that if a page is completely removed, although it will not be linked anymore, it will still exist. This is a known [problem](https://github.com/r-lib/actions/commit/dabdc15316de2c2ca1837e1df08d5feb1b55607a) that apparently there's currently no good known workaround for. In the r2dii packages I [implemented a manual switch](https://github.com/RMI-PACTA/r2dii.match/pull/506) that one can use to wipe old files that should no longer exist.